### PR TITLE
feat: filter out non projects from sln

### DIFF
--- a/lua/easy-dotnet/parsers/sln-parse.lua
+++ b/lua/easy-dotnet/parsers/sln-parse.lua
@@ -17,7 +17,7 @@ M.get_projects_from_sln = function(solutionFilePath)
 
   local projectLines = extensions.filter(file:lines(), function(line)
     local id, name, path = line:match(regexp)
-    if id and name and path then
+    if id and name and path and path:match("%.csproj$") then
       return true
     end
     return false


### PR DESCRIPTION
When parsing the sln file it picks up other non-projects like e.g "Tests", "Solution Items" etc.. These are sort of groupings defined in the sln file but of no interest when performing any of the actions