### PR TITLE
fix: terminal commands not executing correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
           end
         }
         local command = commands[action]() .. "\r"
-        vim.cmd('term')
-        vim.cmd('startinsert!')
-        vim.api.nvim_feedkeys(string.format("%s", command), 'n', true)
+        vim.cmd("vsplit")
+        vim.cmd("term " .. command)
       end,
       secrets = {
         path = get_secret_path

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -31,9 +31,8 @@ return {
       end
     }
     local command = commands[action]() .. "\r"
-    vim.cmd('term')
-    vim.cmd('startinsert!')
-    vim.api.nvim_feedkeys(string.format("%s", command), 'n', true)
+    vim.cmd("vsplit")
+    vim.cmd("term " .. command)
   end,
   secrets = {
     path = get_secret_path,


### PR DESCRIPTION
Fixes an error where the `dotnet build` command would not run correctly using the default readme configuration