### PR TITLE
feat: add <leader>R for running all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Integrated test runner inspired by Rider IDE
 - `E` -> Expand all
 - `o` -> Expand/collapse under cursor
 - `<leader>r` -> Run test under cursor
+- `<leader>R` -> Run all tests
 - `<leader>p` -> Peek stacktrace on failed test
 
 ## Outdated


### PR DESCRIPTION
Add a keymap for running all tests independent of which test is focused. Nice for when a test does not belong to a namespace.

Improves the issues mentioned in #33