### PR TITLE
feat(testrunner): toggle failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Integrated test runner inspired by Rider IDE
 - `<leader>r` -> Run test under cursor
 - `<leader>R` -> Run all tests
 - `<leader>p` -> Peek stacktrace on failed test
+- `<leader>fe` -> Show only failed tests
 
 ## Outdated
 

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -183,8 +183,39 @@ local function run_test_suite(name, win)
     })
 end
 
+local function isAnyErr(lines)
+  local err = false
+  for _, value in ipairs(lines) do
+    if value.icon == resultIcons.failed then
+      err = true
+      return err
+    end
+  end
+
+  return err
+end
+
+local function filter_failed_tests(win)
+  if win.filter == nil and isAnyErr(win.lines) then
+    for _, value in ipairs(win.lines) do
+      if value.icon ~= resultIcons.failed then
+        value.hidden = true
+      end
+    end
+    win.filter = "failed"
+  else
+    for _, value in ipairs(win.lines) do
+      value.hidden = false
+    end
+    win.filter = nil
+  end
+  win.refreshLines()
+end
 
 local keymaps = {
+  ["<leader>fe"] = function(_, _, win)
+    filter_failed_tests(win)
+  end,
   ["E"] = function(_, _, win)
     for _, value in ipairs(win.lines) do
       value.hidden = false

--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -7,6 +7,7 @@ local M = {
   modifiable = false,
   buf_name = "",
   filetype = "",
+  filter = nil,
   keymap = {}
 }
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -86,12 +86,12 @@ M.runner = function(options)
   end
 
   local win = require("easy-dotnet.test-runner.render")
+  local is_reused = win.buf ~= nil
   win.buf_name = "Test manager"
   win.filetype = "easy-dotnet"
   win.setKeymaps(require("easy-dotnet.test-runner.keymaps")).render()
 
-  -- TODO: figure out a better way to check if buffer was reused
-  if #win.lines > 2 then
+  if is_reused then
     return
   end
 


### PR DESCRIPTION
Added keymap `<leader>fe` to filter only failed testruns, requires atleast one failed test to be present and removes inconclusive, passed and skipped tests

Fixes: #36