### PR TITLE
feat(testrunner): flat test groups

### DIFF
--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -34,7 +34,7 @@ end
 local function run_all(win)
   local matches = {}
   for _, line in ipairs(win.lines) do
-    table.insert(matches, { ref = line, line = line.value })
+    table.insert(matches, { ref = line, line = line.ns })
     line.icon = "<Running>"
   end
   win.refreshLines()
@@ -110,8 +110,8 @@ local function run_test_suite(name, win)
   local matches = {}
   local suite_name = name
   for _, line in ipairs(win.lines) do
-    if line.value:match(suite_name) then
-      table.insert(matches, { ref = line, line = line.value })
+    if line.ns:match(suite_name) then
+      table.insert(matches, { ref = line, line = line.ns })
       line.icon = "<Running>"
     end
   end
@@ -239,7 +239,7 @@ local keymaps = {
 
     local newLines = {}
     for _, lineDef in ipairs(win.lines) do
-      if lineDef.value:match(line.value) then
+      if lineDef.ns:match(line.ns) then
         if lineDef ~= line then
           lineDef.hidden = action == "collapse" and true or false
         end
@@ -278,10 +278,10 @@ local keymaps = {
   end,
   ["<leader>r"] = function(_, line, win)
     if line.collapsable then
-      run_test_suite(line.value, win)
+      run_test_suite(line.ns, win)
       return
     end
-    local original_line = line.value
+    local original_line = line.ns
     local sln_parse = require("easy-dotnet.parsers.sln-parse")
     local csproj_parse = require("easy-dotnet.parsers.csproj-parse")
     line.icon = "<Running>"
@@ -296,12 +296,12 @@ local keymaps = {
           if data then
             local result = nil
             for index, stdout_line in ipairs(data) do
-              local failed = stdout_line:match(string.format("%s %s", "Failed", line.value))
+              local failed = stdout_line:match(string.format("%s %s", "Failed", line.ns))
               if failed ~= nil then
                 line.expand = peekStackTrace(index, data)
                 result = "Failed"
               end
-              local skipped = stdout_line:match(string.format("%s %s", "Skipped", line.value))
+              local skipped = stdout_line:match(string.format("%s %s", "Skipped", line.ns))
 
               if skipped ~= nil then
                 result = "Skipped"

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -18,6 +18,11 @@ local function expand_test_names_with_flags(test_names)
       segment_count = segment_count + 1
     end
 
+    if segment_count == 1 then
+      full_test_name = "unnamed." .. trim(full_test_name)
+    end
+    segment_count = 2
+
     -- Reset the parts and segment_count for actual processing
     parts = {}
     local current_count = 0

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -18,10 +18,12 @@ local function expand_test_names_with_flags(test_names)
       segment_count = segment_count + 1
     end
 
+    local is_flat = false
     if segment_count == 1 then
       full_test_name = "unnamed." .. trim(full_test_name)
+      segment_count = 2
+      is_flat = true
     end
-    segment_count = 2
 
     -- Reset the parts and segment_count for actual processing
     parts = {}
@@ -38,8 +40,10 @@ local function expand_test_names_with_flags(test_names)
         local is_full_path = (current_count == segment_count)
         table.insert(expanded,
           {
-            value = concatenated,
+            ns = concatenated,
+            value = trim(part),
             is_full_path = is_full_path,
+            is_flat = is_flat,
             indent = current_count - 1,
             preIcon = is_full_path == false and "📂" or "🧪"
           })
@@ -125,6 +129,7 @@ M.runner = function(options)
               table.insert(lines,
                 {
                   value = test.value,
+                  ns = test.ns,
                   collapsable = test.is_full_path == false,
                   indent = test.indent,
                   preIcon = test.preIcon


### PR DESCRIPTION
It works now but breaks test execution, need to handle this in filter code
Some reserved namespace for flat tests and also strip namespace and use display name for dotnet filter

- Removed namespace from testrunner cascade for a cleaner visual look