### PR TITLE
fix!: get_environment_variables picking wrong launchsettings file

### DIFF
--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -22,6 +22,11 @@ end
 M.get_environment_variables = function(project_name, relative_project_path)
   local launchSettings = vim.fs.joinpath(relative_project_path, "Properties", "launchSettings.json")
 
+  local stat = vim.loop.fs_stat(launchSettings)
+  if stat == nil then
+    return nil
+  end
+
   local success, result = pcall(vim.fn.json_decode, vim.fn.readfile(launchSettings, ""))
   if not success then
     return nil, "Error parsing JSON: " .. result


### PR DESCRIPTION
BREAKING CHANGE: The `get_environment_variables` function has been refactored, which introduces a breaking change.
It now takes a second argument project_path. This is to ensure the correct launchsettings.json file is picked.

```lua
local dll = ensure_dll()
local vars = dotnet.get_environment_variables(dll.project_name, dll.relative_project_path)

```
