### PR TITLE
feat(testrunner): v2 testrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ Integrated test runner inspired by Rider IDE
   - [x] Unit test name
   - [x] Collapsable hieararchy 
   - [x] Peek stack trace
-- [x] Resolve test results from selected test scope
+  - [x] Run sln,project,namespace,test
+  - [x] Aggregate test results
+  - [x] Go to file (only for failed tests)
 
 ### Keymaps
 - `W` -> Collapse all

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Dotnet new
 ## Testrunner
 
 Integrated test runner inspired by Rider IDE
-![image](https://github.com/user-attachments/assets/27955253-cb41-4f47-8586-2b4d068ec538)
+![image](https://github.com/user-attachments/assets/d05d0f3a-d03a-4184-9dd4-e5502eedc061)
+![image](https://github.com/user-attachments/assets/4855bd73-265d-4b53-91e8-0728612a2016)
 
 - [x] Basic test runner window
   - [x] Grouped by namespace
@@ -188,6 +189,7 @@ Integrated test runner inspired by Rider IDE
 - `<leader>R` -> Run all tests
 - `<leader>p` -> Peek stacktrace on failed test
 - `<leader>fe` -> Show only failed tests
+- `<leader>gf` -> Go to file (only works inside stacktrace float)
 
 ## Outdated
 

--- a/lua/easy-dotnet/actions/build.lua
+++ b/lua/easy-dotnet/actions/build.lua
@@ -104,6 +104,7 @@ M.build_project_quickfix = function(use_default)
     if csproj == nil then
       vim.notify(messages.no_project_definition_found)
     end
+    --TODO: constants.get_data_dir
     local logPath = vim.fn.stdpath "data" .. "/easy-dotnet/build.log"
     local command = "dotnet build " .. csproj .. " /flp:v=q /flp:logfile=" .. logPath
     vim.fn.jobstart(command, {
@@ -125,6 +126,7 @@ M.build_project_quickfix = function(use_default)
       return
     end
     vim.notify("Building...")
+    --TODO: constans.get_data_directory
     local logPath = vim.fn.stdpath "data" .. "/easy-dotnet/build.log"
     local command = "dotnet build " .. project.path .. " /flp:v=q /flp:logfile=" .. logPath
     vim.fn.jobstart(command, {

--- a/lua/easy-dotnet/actions/restore.lua
+++ b/lua/easy-dotnet/actions/restore.lua
@@ -7,7 +7,6 @@ local error_messages = require("easy-dotnet.error-messages")
 ---@param term function
 M.restore = function(term)
   local project = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
-  require("easy-dotnet.debug").write_to_log(project)
   if project == nil then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/constants.lua
+++ b/lua/easy-dotnet/constants.lua
@@ -2,5 +2,12 @@ local M = {}
 
 M.ns_id = vim.api.nvim_create_namespace('easy-dotnet')
 
+M.get_data_directory = function()
+  local dir = vim.fs.joinpath(vim.fn.stdpath("data"), "easy-dotnet")
+  local file_utils = require("easy-dotnet.file-utils")
+  file_utils.ensure_directory_exists(dir)
+  return dir
+end
+
 
 return M

--- a/lua/easy-dotnet/debug.lua
+++ b/lua/easy-dotnet/debug.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.write_to_log = function(message)
+  --TODO: constants.get_data_dir
   local log_path = vim.fn.stdpath "data" .. "/easy-dotnet-log.txt"
   -- Open the file in append mode
   local file, err = vim.loop.fs_open(log_path, "a", 438) -- 438 is the octal value for file permissions 0666

--- a/lua/easy-dotnet/default-manager.lua
+++ b/lua/easy-dotnet/default-manager.lua
@@ -20,6 +20,7 @@ local function get_property(type)
 end
 
 local function get_or_create_cache_dir()
+  --TODO: constants.get_data_dir
   local dir = vim.fs.joinpath(vim.fn.stdpath("data"), "easy-dotnet")
   local file_utils = require("easy-dotnet.file-utils")
   file_utils.ensure_directory_exists(dir)

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -1,3 +1,7 @@
+---@class TestRunnerOptions
+---@field noBuild boolean
+---@field noRestore boolean
+
 local function get_secret_path(secret_guid)
   local path = ""
   local home_dir = vim.fn.expand('~')
@@ -37,6 +41,7 @@ return {
   secrets = {
     path = get_secret_path,
   },
+  ---@type TestRunnerOptions
   test_runner = {
     noBuild = true,
     noRestore = true,

--- a/lua/easy-dotnet/outdated/outdated.lua
+++ b/lua/easy-dotnet/outdated/outdated.lua
@@ -46,6 +46,7 @@ end
 M.outdated = function()
   local path = vim.fn.expand("%")
   if path:match(".csproj$") then
+    --TODO: constants.get_data_dir
     local outPath = vim.fn.stdpath("data") .. "/easy-dotnet/package.json"
     local cmd = string.format("dotnet-outdated %s --output %s", path, outPath)
     vim.fn.jobstart(cmd, {

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -1,16 +1,15 @@
-local window      = require "easy-dotnet.test-runner.window"
+local window = require "easy-dotnet.test-runner.window"
+
 local resultIcons = {
   passed = "✔",
   skipped = "⏸",
   failed = "❌"
 }
 
-
 local function aggregateStatus(matches)
   for _, namespace in ipairs(matches) do
     if (namespace.ref.collapsable == true) then
       local worstStatus = nil
-      --TODO: check array for worst status
       for _, res in ipairs(matches) do
         if res.line:match(namespace.line) then
           if (res.ref.icon == resultIcons.failed) then

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -267,18 +267,24 @@ local keymaps = {
     local path = get_path_from_stack_trace(line.expand)
 
     if path ~= nil then
+      local ns_id = require("easy-dotnet.constants").ns_id
       local contents = vim.fn.readfile(path.path)
 
       local file_float = window.new_float():pos_center():write_buf(contents):buf_set_filetype("csharp"):create()
-
-      vim.api.nvim_win_set_cursor(file_float.win, { path.line, 0 })
-      local ns_id = require("easy-dotnet.constants").ns_id
 
       local s = {}
       for _, value in ipairs(line.expand) do
         table.insert(s, { value, "ErrorMsg" })
       end
 
+      vim.keymap.set("n", "<leader>gf", function()
+        vim.api.nvim_win_close(file_float.win, true)
+        vim.cmd(string.format("edit %s", path.path))
+        vim.api.nvim_win_set_cursor(0, { path.line, 0 })
+        vim.api.nvim_buf_add_highlight(0, ns_id, "ErrorMsg", path.line - 1, 0, -1)
+      end, { silent = true, noremap = true, buffer = file_float.buf })
+
+      vim.api.nvim_win_set_cursor(file_float.win, { path.line, 0 })
       vim.api.nvim_buf_set_virtual_text(file_float.buf, ns_id, path.line - 1, s, {})
     end
   end,

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -362,8 +362,11 @@ local keymaps = {
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, line.expand)
     vim.api.nvim_buf_set_option(buf, 'modifiable', false)
   end,
-  ["<leader>R"] = function(_, _, win)
-    run_sln(win)
+  ["<leader>R"] = function(_, line, win)
+    local projects = require("easy-dotnet.parsers.sln-parse").get_projects_from_sln(line.solution_file_path)
+    for _, value in ipairs(projects) do
+      run_csproject(win, value.path)
+    end
   end,
   ---@param line Test
   ["<leader>r"] = function(_, line, win)

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -5,6 +5,64 @@ local resultIcons = {
   failed = "❌"
 }
 
+
+local function aggregateStatus(matches)
+  for _, namespace in ipairs(matches) do
+    if (namespace.ref.collapsable == true) then
+      local worstStatus = nil
+      --TODO: check array for worst status
+      for _, res in ipairs(matches) do
+        if res.line:match(namespace.line) then
+          if (res.ref.icon == resultIcons.failed) then
+            worstStatus = resultIcons.failed
+            namespace.ref.expand = res.ref.expand
+          elseif res.ref.icon == resultIcons.skipped then
+            if worstStatus ~= resultIcons.failed then
+              worstStatus = resultIcons.skipped
+            end
+          end
+        end
+      end
+      namespace.ref.icon = worstStatus == nil and resultIcons.passed or worstStatus
+    end
+  end
+end
+
+
+local function parse_status(result, test_line)
+  --TODO: handle more cases like cancelled etc...
+  if result.outcome == "Passed" then
+    test_line.icon = resultIcons.passed
+  elseif result.outcome == "Failed" then
+    test_line.icon = resultIcons.failed
+    test_line.expand = vim.split(result.stackTrace, "\n")
+  elseif result.outcome == "NotExecuted" then
+    test_line.icon = resultIcons.skipped
+  else
+    test_line.icon = "??"
+  end
+end
+
+
+local function parse_log_file(relative_log_file_path, win, matches)
+  require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
+    ---@param unit_test_results TestCase[]
+    function(unit_test_results)
+      for _, match in ipairs(matches) do
+        local test_line = match.ref
+        if test_line.type == "test" or test_line.type == "subcase" then
+          local result = unit_test_results[match.line]
+          if result == nil then
+            error(string.format("Status of %s was not present in xml file", match.line))
+          end
+          parse_status(result, test_line)
+        end
+      end
+      aggregateStatus(matches)
+      win.refreshLines()
+    end)
+end
+
 local function run_csproject(win, cs_project_path)
   local log_file_name = string.format("%s.xml", cs_project_path:match("([^/\\]+)$"))
   local normalized_path = cs_project_path:gsub('\\', '/')
@@ -25,78 +83,8 @@ local function run_csproject(win, cs_project_path)
   vim.fn.jobstart(
     string.format("dotnet test --nologo --no-build --no-restore %s --logger='trx;logFileName=%s'", cs_project_path,
       log_file_name), {
-      on_stdout = function(_, data)
-        -- if data == nil then
-        --   error("Failed to parse dotnet test output")
-        -- end
-        -- for stdoutIndex, stdout in ipairs(data) do
-        --   for _, match in ipairs(matches) do
-        --     local failed = stdout:match(string.format("%s %s", "Failed", match.line))
-        --     if failed ~= nil then
-        --       match.ref.icon = resultIcons.failed
-        --       match.ref.expand = peekStackTrace(stdoutIndex, data)
-        --     end
-        --
-        --     local skipped = stdout:match(string.format("%s %s", "Skipped", match.line))
-        --     if skipped ~= nil then
-        --       match.ref.icon = resultIcons.skipped
-        --     end
-        --   end
-        -- end
-        -- win.refreshLines()
-      end,
       on_exit = function(_, code)
-        require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
-          ---@param unit_test_results TestCase[]
-          function(unit_test_results)
-            for _, test_line in ipairs(win.lines) do
-              local result = unit_test_results[test_line.namespace]
-
-              if result == nil then
-                --TODO: some fatal error here or sumtin
-              end
-
-              if result ~= nil then
-                --TODO: handle more cases like cancelled etc...
-                if result.outcome == "Passed" then
-                  test_line.icon = resultIcons.passed
-                elseif result.outcome == "Failed" then
-                  test_line.icon = resultIcons.failed
-                  test_line.expand = vim.split(result.stackTrace, "\n")
-                elseif result.outcome == "NotExecuted" then
-                  test_line.icon = resultIcons.skipped
-                else
-                  test_line.icon = "??"
-                end
-              end
-            end
-
-            --aggregate namespaces/csproject status
-            for _, namespace in ipairs(matches) do
-              if (namespace.ref.collapsable == true) then
-                local worstStatus = nil
-                --TODO: check array for worst status
-                for _, res in ipairs(matches) do
-                  if res.line:match(namespace.line) then
-                    if (res.ref.icon == resultIcons.failed) then
-                      worstStatus = resultIcons.failed
-                      namespace.ref.expand = res.ref.expand
-                    elseif res.ref.icon == resultIcons.skipped then
-                      if worstStatus ~= resultIcons.failed then
-                        worstStatus = resultIcons.skipped
-                      end
-                    end
-                  end
-                end
-                namespace.ref.icon = worstStatus == nil and resultIcons.passed or worstStatus
-              end
-            end
-            win.refreshLines()
-          end)
-
-        -- if code ~= 0 then
-        --   vim.notify("dotnet test command failed")
-        -- end
+        parse_log_file(relative_log_file_path, win, matches)
       end
     })
 end
@@ -123,77 +111,8 @@ local function run_test_group(line, win)
     string.format("dotnet test --filter='%s' --nologo --no-build --no-restore %s --logger='trx;logFileName=%s'",
       suite_name, line.cs_project_path, log_file_name),
     {
-      on_stdout = function(_, data)
-        -- if data == nil then
-        --   error("Failed to parse dotnet test output")
-        -- end
-        -- for stdoutIndex, stdout in ipairs(data) do
-        --   for _, match in ipairs(matches) do
-        --     local failed = stdout:match(string.format("%s %s", "Failed", match.line))
-        --     if failed ~= nil then
-        --       match.ref.icon = resultIcons.failed
-        --       match.ref.expand = peekStackTrace(stdoutIndex, data)
-        --     end
-        --
-        --     local skipped = stdout:match(string.format("%s %s", "Skipped", match.line))
-        --     if skipped ~= nil then
-        --       match.ref.icon = resultIcons.skipped
-        --     end
-        --   end
-        -- end
-        -- win.refreshLines()
-      end,
-      on_exit = function(_, code)
-        require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
-          ---@param unit_test_results TestCase[]
-          function(unit_test_results)
-            for _, test_line in ipairs(win.lines) do
-              local result = unit_test_results[test_line.namespace]
-              if result ~= nil then
-                --TODO: handle more cases like cancelled etc...
-                if result.outcome == "Passed" then
-                  test_line.icon = resultIcons.passed
-                elseif result.outcome == "Failed" then
-                  test_line.icon = resultIcons.failed
-                  test_line.expand = vim.split(result.stackTrace, "\n")
-                elseif result.outcome == "NotExecuted" then
-                  test_line.icon = resultIcons.skipped
-                else
-                  test_line.icon = "??"
-                end
-              else
-                --TODO: throw fatal error
-              end
-            end
-
-
-            for _, namespace in ipairs(matches) do
-              if (namespace.ref.collapsable == true) then
-                local worstStatus = nil
-                --TODO: check array for worst status
-                for _, res in ipairs(matches) do
-                  if res.line:match(namespace.line) then
-                    if (res.ref.icon == resultIcons.failed) then
-                      worstStatus = resultIcons.failed
-                      namespace.ref.expand = res.ref.expand
-                    elseif res.ref.icon == resultIcons.skipped then
-                      if worstStatus ~= resultIcons.failed then
-                        worstStatus = resultIcons.skipped
-                      end
-                    end
-                  end
-                end
-                namespace.ref.icon = worstStatus == nil and resultIcons.passed or worstStatus
-              end
-            end
-
-
-            win.refreshLines()
-          end)
-
-        -- if code ~= 0 then
-        --   vim.notify("dotnet test command failed")
-        -- end
+      on_exit = function()
+        parse_log_file(relative_log_file_path, win, matches)
       end
     })
 end
@@ -221,77 +140,8 @@ local function run_test_suite(line, win)
     string.format("dotnet test --filter='%s' --nologo --no-build --no-restore %s --logger='trx;logFileName=%s'",
       suite_name, line.cs_project_path, log_file_name),
     {
-      on_stdout = function(_, data)
-        -- if data == nil then
-        --   error("Failed to parse dotnet test output")
-        -- end
-        -- for stdoutIndex, stdout in ipairs(data) do
-        --   for _, match in ipairs(matches) do
-        --     local failed = stdout:match(string.format("%s %s", "Failed", match.line))
-        --     if failed ~= nil then
-        --       match.ref.icon = resultIcons.failed
-        --       match.ref.expand = peekStackTrace(stdoutIndex, data)
-        --     end
-        --
-        --     local skipped = stdout:match(string.format("%s %s", "Skipped", match.line))
-        --     if skipped ~= nil then
-        --       match.ref.icon = resultIcons.skipped
-        --     end
-        --   end
-        -- end
-        -- win.refreshLines()
-      end,
-      on_exit = function(_, code)
-        require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
-          ---@param unit_test_results TestCase[]
-          function(unit_test_results)
-            for _, test_line in ipairs(win.lines) do
-              local result = unit_test_results[test_line.namespace]
-              if result ~= nil then
-                --TODO: handle more cases like cancelled etc...
-                if result.outcome == "Passed" then
-                  test_line.icon = resultIcons.passed
-                elseif result.outcome == "Failed" then
-                  test_line.icon = resultIcons.failed
-                  test_line.expand = vim.split(result.stackTrace, "\n")
-                elseif result.outcome == "NotExecuted" then
-                  test_line.icon = resultIcons.skipped
-                else
-                  test_line.icon = "??"
-                end
-              else
-                --TODO: throw fatal error
-              end
-            end
-
-
-            for _, namespace in ipairs(matches) do
-              if (namespace.ref.collapsable == true) then
-                local worstStatus = nil
-                --TODO: check array for worst status
-                for _, res in ipairs(matches) do
-                  if res.line:match(namespace.line) then
-                    if (res.ref.icon == resultIcons.failed) then
-                      worstStatus = resultIcons.failed
-                      namespace.ref.expand = res.ref.expand
-                    elseif res.ref.icon == resultIcons.skipped then
-                      if worstStatus ~= resultIcons.failed then
-                        worstStatus = resultIcons.skipped
-                      end
-                    end
-                  end
-                end
-                namespace.ref.icon = worstStatus == nil and resultIcons.passed or worstStatus
-              end
-            end
-
-
-            win.refreshLines()
-          end)
-
-        -- if code ~= 0 then
-        --   vim.notify("dotnet test command failed")
-        -- end
+      on_exit = function()
+        parse_log_file(relative_log_file_path, win, matches)
       end
     })
 end
@@ -424,21 +274,19 @@ local keymaps = {
       vim.api.nvim_buf_set_virtual_text(file_float.buf, ns_id, path.line - 1, s, {})
     end
   end,
-  ["<leader>R"] = function(_, line, win)
-    local projects = require("easy-dotnet.parsers.sln-parse").get_projects_from_sln(line.solution_file_path)
-    for _, value in ipairs(projects) do
-      if value.isTestProject == true then
-        run_csproject(win, value.path)
+  ["<leader>R"] = function(_, _, win)
+    for _, value in ipairs(win.lines) do
+      if value.type == "csproject" then
+        run_csproject(win, value.cs_project_path)
       end
     end
   end,
   ---@param line Test
   ["<leader>r"] = function(_, line, win)
     if line.type == "sln" then
-      local projects = require("easy-dotnet.parsers.sln-parse").get_projects_from_sln(line.solution_file_path)
-      for _, value in ipairs(projects) do
-        if value.isTestProject == true then
-          run_csproject(win, value.path)
+      for _, value in ipairs(win.lines) do
+        if value.type == "csproject" and value.solution_file_path == line.solution_file_path then
+          run_csproject(win, value.cs_project_path)
         end
       end
     elseif line.type == "csproject" then
@@ -446,12 +294,10 @@ local keymaps = {
     elseif line.type == "namespace" then
       run_test_suite(line, win)
     elseif line.type == "test_group" then
-      vim.notify("Run test group")
       run_test_group(line, win)
     elseif line.type == "subcase" then
       vim.notify("Running specific subcases is not supported")
     elseif line.type == "test" then
-      vim.notify(line.cs_project_path)
       local log_file_name = string.format("%s.xml", line.name)
       local normalized_path = line.cs_project_path:gsub('\\', '/')
       local directory_path = normalized_path:match('^(.*)/[^/]*$')
@@ -465,63 +311,17 @@ local keymaps = {
       line.icon = "<Running>"
       vim.fn.jobstart(
         command, {
-          stdout_buffered = true,
-          on_stdout = function(_, data)
-            -- if data then
-            --   local result = nil
-            --   for index, stdout_line in ipairs(data) do
-            --     local failed = stdout_line:match(string.format("%s %s", "Failed", line.namespace))
-            --     if failed ~= nil then
-            --       line.expand = peekStackTrace(index, data)
-            --       result = "Failed"
-            --     end
-            --     local skipped = stdout_line:match(string.format("%s %s", "Skipped", line.namespace))
-            --
-            --     if skipped ~= nil then
-            --       result = "Skipped"
-            --     end
-            --   end
-            --   if result == nil then
-            --     result = "Passed"
-            --   end
-            --
-            --   line.icon = getIcon(result)
-            --   win.refreshLines()
-          end,
-          on_exit = function(_, code)
+          on_exit = function()
             require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
               ---@param unit_test_results TestCase
               function(unit_test_results)
-                require("easy-dotnet.debug").write_to_log("peek")
-                require("easy-dotnet.debug").write_to_log(unit_test_results)
                 local result = unit_test_results[line.namespace]
-
-                if result ~= nil then
-                  if result.outcome == "Passed" then
-                    line.icon = resultIcons.passed
-                  elseif result.outcome == "Failed" then
-                    line.icon = resultIcons.failed
-                    line.expand = vim.split(unit_test_results.stackTrace, "\n")
-                  elseif result.outcome == "NotExecuted" then
-                    line.icon = resultIcons.skipped
-                  else
-                    line.icon = "??"
-                  end
-                else
-                  --TODO: throw fatal error
+                if result == nil then
+                  error(string.format("Status of %s was not present in xml file", line.namespace))
                 end
-
+                parse_status(result, line)
                 win.refreshLines()
               end)
-
-
-            -- TODO: If the tests are failing then exit code 1 is expected
-            -- if code ~= 0 then
-            --   if (line.icon == "<Running>") then
-            --     line.icon = "<Panic! command failed>"
-            --     win.refreshLines()
-            --   end
-            -- end
           end
         })
 

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -243,6 +243,17 @@ local keymaps = {
         end
         table.insert(newLines, lineDef)
       end
+    elseif line.type == "test_group" then
+      for _, test_line in ipairs(win.lines) do
+        if test_line.type == "subcase" and line.namespace == test_line.namespace:gsub("%b()", "") then
+          if line ~= test_line then
+            test_line.hidden = action == "collapse" and true or false
+          end
+        end
+        table.insert(newLines, test_line)
+      end
+
+      --TODO: open all children
     elseif line.type == "test" then
       --TODO: go to file
       return

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -368,8 +368,10 @@ local keymaps = {
   ---@param line Test
   ["<leader>r"] = function(_, line, win)
     if line.type == "sln" then
-      vim.notify("Running sln")
-      run_sln(win)
+      local projects = require("easy-dotnet.parsers.sln-parse").get_projects_from_sln(line.solution_file_path)
+      for _, value in ipairs(projects) do
+        run_csproject(win, value.path)
+      end
     elseif line.type == "csproject" then
       vim.notify("Running csproject")
       run_csproject(win, line.cs_project_path)

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -252,8 +252,6 @@ local keymaps = {
         end
         table.insert(newLines, test_line)
       end
-
-      --TODO: open all children
     elseif line.type == "test" then
       --TODO: go to file
       return
@@ -318,7 +316,6 @@ local keymaps = {
         "dotnet test --filter='%s' --nologo --no-build --no-restore %s --logger='trx;logFileName=%s'",
         line.namespace:gsub("%b()", ""), line.cs_project_path, log_file_name)
 
-      require("easy-dotnet.debug").write_to_log(command)
       line.icon = "<Running>"
       vim.fn.jobstart(
         command, {
@@ -343,4 +340,5 @@ local keymaps = {
     end
   end
 }
+
 return keymaps

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -270,22 +270,27 @@ local keymaps = {
       local ns_id = require("easy-dotnet.constants").ns_id
       local contents = vim.fn.readfile(path.path)
 
-      local file_float = window.new_float():pos_center():write_buf(contents):buf_set_filetype("csharp"):create()
+      local file_float = window.new_float():pos_left():write_buf(contents):buf_set_filetype("csharp"):create()
 
-      local s = {}
-      for _, value in ipairs(line.expand) do
-        table.insert(s, { value, "ErrorMsg" })
-      end
+      local stack_trace = window:new_float():link_close(file_float):pos_right():write_buf(line.expand):create()
 
-      vim.keymap.set("n", "<leader>gf", function()
+      local function go_to_file()
         vim.api.nvim_win_close(file_float.win, true)
         vim.cmd(string.format("edit %s", path.path))
         vim.api.nvim_win_set_cursor(0, { path.line, 0 })
         vim.api.nvim_buf_add_highlight(0, ns_id, "ErrorMsg", path.line - 1, 0, -1)
+      end
+
+      vim.keymap.set("n", "<leader>gf", function()
+        go_to_file()
       end, { silent = true, noremap = true, buffer = file_float.buf })
 
+      vim.keymap.set("n", "<leader>gf", function()
+        go_to_file()
+      end, { silent = true, noremap = true, buffer = stack_trace.buf })
+
+
       vim.api.nvim_win_set_cursor(file_float.win, { path.line, 0 })
-      vim.api.nvim_buf_set_virtual_text(file_float.buf, ns_id, path.line - 1, s, {})
     end
   end,
   ["<leader>R"] = function(_, _, win)

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -373,13 +373,10 @@ local keymaps = {
         run_csproject(win, value.path)
       end
     elseif line.type == "csproject" then
-      vim.notify("Running csproject")
       run_csproject(win, line.cs_project_path)
     elseif line.type == "namespace" then
-      vim.notify("Running namespace")
       run_test_suite(line, win)
     elseif line.type == "test" then
-      vim.notify("Running Test ")
       line.icon = "<Running>"
       vim.fn.jobstart(
         string.format("dotnet test --filter='%s' --nologo --no-build --no-restore %s", line.namespace,

--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -114,6 +114,7 @@ local function buffer_exists(name)
   end
   return nil
 end
+---
 --- Renders the buffer
 M.render = function()
   -- if buf exists, restore
@@ -126,7 +127,6 @@ M.render = function()
   printLines()
   setBufferOptions()
   setMappings()
-  --TODO: add highlights
   return M
 end
 

--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -18,23 +18,6 @@ local function setBufferOptions()
   vim.api.nvim_buf_set_option(M.buf, "filetype", M.filetype)
 end
 
-local function printLines()
-  vim.api.nvim_buf_set_option(M.buf, "modifiable", true)
-  local stringLines = {}
-  for _, line in ipairs(M.lines) do
-    if line.hidden == false or line.hidden == nil then
-      local formatted = string.format("%s%s%s%s", string.rep(" ", line.indent or 0),
-        line.preIcon and (line.preIcon .. " ") or "", line.name,
-        line.icon and (" " .. line.icon) or "")
-      table.insert(stringLines, formatted)
-    end
-  end
-
-  vim.api.nvim_buf_set_lines(M.buf, 0, -1, true, stringLines)
-  vim.api.nvim_buf_set_option(M.buf, "modifiable", M.modifiable)
-end
-
-
 -- Translates line num to M.lines index accounting for hidden lines
 local function translateIndex(line_num)
   local i = 0
@@ -53,6 +36,48 @@ local function translateIndex(line_num)
 
   return r
 end
+
+
+local function apply_highlights()
+  local ns_id = require("easy-dotnet.constants").ns_id
+
+  --Some lines are hidden so tracking the actual line numbers using shadow_index
+  local shadow_index = 0
+  for _, value in ipairs(M.lines) do
+    if value.hidden == false or value.hidden == nil then
+      shadow_index = shadow_index + 1
+      if value.highlight ~= nil then
+        if type(value.highlight) == "string" then
+          vim.api.nvim_buf_add_highlight(M.buf, ns_id, value.highlight, shadow_index - 1, 0, -1)
+        else
+          vim.notify("hl not supported as table")
+        end
+      end
+    end
+  end
+end
+
+local function printLines()
+  vim.api.nvim_buf_set_option(M.buf, "modifiable", true)
+  local stringLines = {}
+  for _, line in ipairs(M.lines) do
+    if line.hidden == false or line.hidden == nil then
+      local formatted = string.format("%s%s%s%s", string.rep(" ", line.indent or 0),
+        line.preIcon and (line.preIcon .. " ") or "", line.name,
+        line.icon and (" " .. line.icon) or "")
+      table.insert(stringLines, formatted)
+    end
+  end
+
+  vim.api.nvim_buf_set_lines(M.buf, 0, -1, true, stringLines)
+  vim.api.nvim_buf_set_option(M.buf, "modifiable", M.modifiable)
+
+  apply_highlights()
+end
+
+
+
+
 
 local function setMappings()
   if M.keymap == nil then

--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -46,12 +46,14 @@ local function apply_highlights()
   for _, value in ipairs(M.lines) do
     if value.hidden == false or value.hidden == nil then
       shadow_index = shadow_index + 1
-      if value.highlight ~= nil then
-        if type(value.highlight) == "string" then
-          vim.api.nvim_buf_add_highlight(M.buf, ns_id, value.highlight, shadow_index - 1, 0, -1)
-        else
-          vim.notify("hl not supported as table")
-        end
+      if value.icon == "❌" then
+        vim.api.nvim_buf_add_highlight(M.buf, ns_id, "ErrorMsg", shadow_index - 1, 0, -1)
+      elseif value.icon == "<Running>" then
+        vim.api.nvim_buf_add_highlight(M.buf, ns_id, "SpellCap", shadow_index - 1, 0, -1)
+      elseif value.icon == "✔" then
+        vim.api.nvim_buf_add_highlight(M.buf, ns_id, "Character", shadow_index - 1, 0, -1)
+      elseif value.highlight ~= nil and type(value.highlight) == "string" then
+        vim.api.nvim_buf_add_highlight(M.buf, ns_id, value.highlight, shadow_index - 1, 0, -1)
       end
     end
   end
@@ -64,7 +66,7 @@ local function printLines()
     if line.hidden == false or line.hidden == nil then
       local formatted = string.format("%s%s%s%s", string.rep(" ", line.indent or 0),
         line.preIcon and (line.preIcon .. " ") or "", line.name,
-        line.icon and (" " .. line.icon) or "")
+        line.icon and line.icon ~= "✔" and (" " .. line.icon) or "")
       table.insert(stringLines, formatted)
     end
   end

--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -24,7 +24,7 @@ local function printLines()
   for _, line in ipairs(M.lines) do
     if line.hidden == false or line.hidden == nil then
       local formatted = string.format("%s%s%s%s", string.rep(" ", line.indent or 0),
-        line.preIcon and (line.preIcon .. " ") or "", line.value,
+        line.preIcon and (line.preIcon .. " ") or "", line.name,
         line.icon and (" " .. line.icon) or "")
       table.insert(stringLines, formatted)
     end

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -9,6 +9,18 @@ local function expand_test_names_with_flags(test_names)
   local expanded = {}
   local seen = {}
 
+  -- Sort the test_names based on the number of segments and lexicographically
+  table.sort(test_names, function(a, b)
+    local a_segment_count = #a:gsub("[^.]+", "")
+    local b_segment_count = #b:gsub("[^.]+", "")
+
+    if a_segment_count == b_segment_count then
+      return a < b -- Lexicographical order if segment counts are the same
+    else
+      return a_segment_count < b_segment_count
+    end
+  end)
+
   for _, full_test_name in ipairs(test_names) do
     local parts = {}
     local segment_count = 0
@@ -33,7 +45,8 @@ local function expand_test_names_with_flags(test_names)
         local is_full_path = (current_count == segment_count)
         table.insert(expanded,
           {
-            value = concatenated,
+            ns = concatenated,
+            value = trim(part),
             is_full_path = is_full_path,
             indent = current_count - 1,
             preIcon = is_full_path == false and "📂" or "🧪"
@@ -51,7 +64,7 @@ local function extract_tests(lines)
 
   -- Extract lines that match the pattern for test names
   for _, line in ipairs(lines) do
-    if not (line:match("^Test run for") or line:match("^No test is available in") or line:match("^The following Tests are available:") or line == "") then
+    if not #(trim(line)) == 0 or not (line:match("^Test run for") or line:match("^No test is available in") or line:match("^The following Tests are available:") or line == "") then
       table.insert(tests, line)
     end
   end
@@ -120,6 +133,7 @@ M.runner = function(options)
               table.insert(lines,
                 {
                   value = test.value,
+                  ns = test.ns,
                   collapsable = test.is_full_path == false,
                   indent = test.indent,
                   preIcon = test.preIcon

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -60,20 +60,21 @@ local function expand_test_names_with_flags(test_names)
           })
         seen[concatenated] = true
       end
-    end
 
-    -- Add the full test name with arguments (if any) or just the base name
-    if has_arguments and not seen[full_test_name] then
-      table.insert(expanded,
-        {
-          ns = trim(full_test_name),
-          value = trim(full_test_name):match("([^.]+%b())$"),
-          is_full_path = true,
-          indent = (segment_count * 2),
-          preIcon = "🧪",
-          type = "subcase"
-        })
-      seen[full_test_name] = true
+
+      -- Add the full test name with arguments (if any) or just the base name
+      if (current_count == segment_count) and has_arguments and not seen[full_test_name] then
+        table.insert(expanded,
+          {
+            ns = trim(full_test_name),
+            value = trim(full_test_name):match("([^.]+%b())$"),
+            is_full_path = true,
+            indent = (segment_count * 2),
+            preIcon = "🧪",
+            type = "subcase"
+          })
+        seen[full_test_name] = true
+      end
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -184,8 +184,6 @@ local function discover_tests_for_project_and_update_lines(project, win)
   })
 end
 
-
-
 M.runner = function(options)
   local mergedOpts = merge_tables(default_options, options or {})
   local sln_parse = require("easy-dotnet.parsers.sln-parse")

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -86,9 +86,8 @@ local function extract_tests(lines)
 
   -- Extract lines that match the pattern for test names
   for _, line in ipairs(lines) do
-    if not #(trim(line)) == 0 or not (line:match("^Test run for") or line:match("^No test is available in") or line:match("^The following Tests are available:") or line == "") then
+    if line:match("^%s%s%s%s%S") ~= nil then
       table.insert(tests, line)
-      -- :gsub("%b()", "")
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -91,7 +91,6 @@ local function extract_tests(lines)
     end
   end
 
-
   return expand_test_names_with_flags(tests)
 end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -135,12 +135,13 @@ local default_options = require("easy-dotnet.options").test_runner
 
 ---@return Test[]
 ---@param project Test
-local function discover_tests_for_project_and_update_lines(project, win)
-  local command = string.format("dotnet test -t --nologo --no-build --no-restore %s", project.cs_project_path)
+---@param options TestRunnerOptions
+local function discover_tests_for_project_and_update_lines(project, win, options)
+  local command = string.format("dotnet test -t --nologo %s %s %s", options.noBuild == true and "--no-build" or "",
+    options.noRestore == true and "--no-restore" or "", project.cs_project_path)
 
   ---@type Test[]
   local lines = {}
-  -- table.insert(lines, project)
 
   vim.fn.jobstart(command, {
     stdout_buffered = true,
@@ -185,6 +186,7 @@ local function discover_tests_for_project_and_update_lines(project, win)
 end
 
 M.runner = function(options)
+  ---@type TestRunnerOptions
   local mergedOpts = merge_tables(default_options, options or {})
   local sln_parse = require("easy-dotnet.parsers.sln-parse")
   local csproj_parse = require("easy-dotnet.parsers.csproj-parse")
@@ -248,7 +250,7 @@ M.runner = function(options)
         expand = {},
         highlight = "Character"
       }
-      discover_tests_for_project_and_update_lines(project, win)
+      discover_tests_for_project_and_update_lines(project, win, mergedOpts)
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -136,13 +136,17 @@ local function discover_tests_for_project_and_update_lines(project, win)
 
   ---@type Test[]
   local lines = {}
-  table.insert(lines, project)
+  -- table.insert(lines, project)
 
   vim.fn.jobstart(command, {
     stdout_buffered = true,
     ---@param data string[]
     on_stdout = function(_, data)
       local tests = extract_tests(data)
+      if #tests == 0 then
+        return
+      end
+      table.insert(lines, project)
 
       for _, test in ipairs(tests) do
         ---@type Test

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -93,7 +93,7 @@ local function extract_tests(lines)
   -- Extract lines that match the pattern for test names
   for _, line in ipairs(lines) do
     if line:match("^%s%s%s%s%S") ~= nil then
-      table.insert(tests, line)
+      table.insert(tests, trim(line))
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -50,7 +50,7 @@ local function expand_test_names_with_flags(test_names)
     for part in base_name:gmatch("[^.]+") do
       table.insert(parts, part)
       current_count = current_count + 1
-      local concatenated = trim(table.concat(parts, "."))
+      local concatenated = table.concat(parts, ".")
 
       if not seen[concatenated] then
         -- Set is_full_path to true only if we are at the last segment
@@ -58,7 +58,7 @@ local function expand_test_names_with_flags(test_names)
         table.insert(expanded,
           {
             ns = concatenated,
-            value = trim(part),
+            value = part,
             is_full_path = is_full_path and not has_arguments,
             indent = (current_count * 2) - 1,
             preIcon = is_full_path == false and "📂" or has_arguments and "📦" or "🧪",
@@ -72,8 +72,8 @@ local function expand_test_names_with_flags(test_names)
     if has_arguments and not seen[full_test_name] then
       table.insert(expanded,
         {
-          ns = trim(full_test_name),
-          value = trim(full_test_name):match("([^.]+%b())$"),
+          ns = full_test_name,
+          value = full_test_name:match("([^.]+%b())$"),
           is_full_path = true,
           indent = (segment_count * 2),
           preIcon = "🧪",

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -177,6 +177,7 @@ local function discover_tests_for_project_and_update_lines(project, win)
     ---@param code number
     on_exit = function(_, code)
       if code ~= 0 then
+        --TODO: check if project was not built
         vim.notify(string.format("Discovering tests for %s failed", project.name))
       end
     end

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -156,6 +156,8 @@ local function discover_tests_for_project_and_update_lines(project, win)
   })
 end
 
+
+
 M.runner = function(options)
   local mergedOpts = merge_tables(default_options, options or {})
   local sln_parse = require("easy-dotnet.parsers.sln-parse")

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -90,6 +90,11 @@ end
 
 local default_options = require("easy-dotnet.options").test_runner
 
+--- @class Highlight
+--- @field group string
+--- @field column_start number | nil
+--- @field column_end number | nil
+
 --- @class Test
 --- @field type "csproject" | "sln" | "namespace" | "test"
 --- @field solution_file_path string
@@ -102,6 +107,7 @@ local default_options = require("easy-dotnet.options").test_runner
 --- @field hidden boolean
 --- @field expand table | nil
 --- @field icon string | nil
+--- @field highlight string | Highlight| nil
 
 
 ---@return Test[]
@@ -188,7 +194,8 @@ M.runner = function(options)
     hidden = false,
     collapsable = true,
     icon = "",
-    expand = {}
+    expand = {},
+    highlight = "Question"
 
   }
   table.insert(lines, sln)
@@ -210,7 +217,8 @@ M.runner = function(options)
         hidden = false,
         collapsable = true,
         icon = "",
-        expand = {}
+        expand = {},
+        highlight = "Character"
       }
       discover_tests_for_project_and_update_lines(project, win)
     end

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -48,7 +48,7 @@ local function expand_test_names_with_flags(test_names)
             ns = concatenated,
             value = trim(part),
             is_full_path = is_full_path,
-            indent = current_count - 1,
+            indent = (current_count * 2) - 1,
             preIcon = is_full_path == false and "📂" or "🧪"
           })
         seen[concatenated] = true
@@ -86,6 +86,112 @@ end
 
 local default_options = require("easy-dotnet.options").test_runner
 
+--- @class Test
+--- @field type "csproject" | "sln" | "namespace" | "test"
+--- @field solution_file_path string
+--- @field cs_project_path string
+--- @field name string
+--- @field namespace string
+--- @field preIcon string
+--- @field collapsable boolean
+--- @field indent number
+--- @field hidden boolean
+--- @field expand table
+--- @field icon string
+
+
+-- local function discover_tests_for_project(project_path, solution_file_path, co)
+--   local command = string.format("dotnet test -t --nologo --no-build --no-restore %s", project_path)
+--   local err_lines = {}
+--   local lines = {}
+--
+--   vim.fn.jobstart(
+--     command, {
+--       stdout_buffered = true,
+--       on_stderr = function(_, data)
+--         for _, line in ipairs(data) do
+--           if #line > 0 then
+--             table.insert(err_lines, { value = line, preIcon = "❌" })
+--           end
+--         end
+--       end,
+--       on_stdout = function(_, data)
+--         if data then
+--           --TODO:find a better way to handle this
+--           if #data == 1 then
+--             --TODO: error handling
+--           else
+--             local tests = extract_tests(data)
+--             for _, test in ipairs(tests) do
+--               ---@type Test
+--               local test_item = {
+--                 name = test.value,
+--                 preIcon = test.preIcon,
+--                 indent = test.indent,
+--                 collapsable = test.is_full_path == false,
+--                 type = test.is_full_path == true and "test" or "namespace",
+--                 namespace = test.ns,
+--                 solution_file_path = solution_file_path,
+--                 cs_project_path = project_path
+--               }
+--               table.insert(lines, test_item)
+--             end
+--           end
+--         end
+--       end,
+--       on_exit = function(_, code)
+--         coroutine.resume(co)
+--         if code ~= 0 then
+--           vim.notify("command failed")
+--           -- -- win.lines = { { value = "Failed to discover tests", preIcon = "❌" } }
+--           -- win.lines = err_lines
+--           -- win.refreshLines()
+--         end
+--       end
+--     })
+--   coroutine.yield()
+--   return lines
+-- end
+--
+--
+---@return Test[]
+local function discover_tests_for_project(project_path, solution_file_path)
+  local command = string.format(
+    "dotnet test -t --nologo --no-build --no-restore %s",
+    project_path
+  )
+
+  -- Use vim.fn.system to run the command synchronously
+  local output = vim.fn.system(command)
+  local exit_code = vim.v.shell_error
+
+  if exit_code ~= 0 then
+    vim.notify("Command failed with exit code: " .. exit_code, vim.log.levels.ERROR)
+    return {}
+  end
+
+  local lines = {}
+  local tests = extract_tests(vim.split(output, "\n", { trimempty = true }))
+
+  for _, test in ipairs(tests) do
+    ---@type Test
+    local test_item = {
+      name = test.value,
+      preIcon = test.preIcon,
+      indent = test.indent + 3,
+      collapsable = not test.is_full_path,
+      type = test.is_full_path and "test" or "namespace",
+      namespace = test.ns,
+      solution_file_path = solution_file_path,
+      cs_project_path = project_path,
+      hidden = true
+    }
+    table.insert(lines, test_item)
+  end
+
+  return lines
+end
+
 M.runner = function(options)
   local mergedOpts = merge_tables(default_options, options or {})
   local sln_parse = require("easy-dotnet.parsers.sln-parse")
@@ -108,53 +214,55 @@ M.runner = function(options)
     return
   end
 
-  local command = string.format("dotnet test -t --nologo %s %s %s", mergedOpts.noBuild == true and "--no-build" or "",
-    mergedOpts.noRestore == true and "--no-restore" or "", solutionFilePath)
-  local err_lines = {}
-  vim.fn.jobstart(
-    command, {
-      stdout_buffered = true,
-      on_stderr = function(_, data)
-        for _, line in ipairs(data) do
-          if #line > 0 then
-            table.insert(err_lines, { value = line, preIcon = "❌" })
-          end
-        end
-      end,
-      on_stdout = function(_, data)
-        if data then
-          --TODO:find a better way to handle this
-          if #data == 1 then
-            win.lines = { { value = "Failed to discover tests", preIcon = "❌" } }
-          else
-            local tests = extract_tests(data)
-            local lines = {}
-            for _, test in ipairs(tests) do
-              table.insert(lines,
-                {
-                  value = test.value,
-                  ns = test.ns,
-                  collapsable = test.is_full_path == false,
-                  indent = test.indent,
-                  preIcon = test.preIcon
-                })
-            end
+  ---@type Test[]
+  local lines = {}
 
-            win.lines = lines
-            win.height = #lines > 20 and 20 or #lines
-          end
-          win.refreshLines()
-        end
-      end,
-      on_exit = function(_, code)
-        if code ~= 0 then
-          vim.notify("command failed")
-          -- win.lines = { { value = "Failed to discover tests", preIcon = "❌" } }
-          win.lines = err_lines
-          win.refreshLines()
-        end
+  --Find sln
+  ---@type Test
+  local sln = {
+    solution_file_path = solutionFilePath,
+    cs_project_path = "",
+    type = "sln",
+    preIcon = "",
+    name = solutionFilePath:match("([^/\\]+)$"),
+    indent = 0,
+    collapsable = true,
+    namespace = "",
+    hidden = false
+  }
+  table.insert(lines, sln)
+
+  local projects = sln_parse.get_projects_from_sln(solutionFilePath)
+
+  for _, value in ipairs(projects) do
+    if value.isTestProject == true then
+      ---@type Test
+      local project = {
+        collapsable = true,
+        cs_project_path = value.path,
+        solution_file_path = solutionFilePath,
+        namespace = "",
+        type = "csproject",
+        name = value.name,
+        indent = 2,
+        preIcon = "",
+        hidden = false
+      }
+      table.insert(lines, project)
+      local tests = discover_tests_for_project(value.path, solutionFilePath)
+      for _, test in ipairs(tests) do
+        table.insert(lines, test)
       end
-    })
+    end
+  end
+
+
+  win.lines = lines
+  win.height = #lines > 20 and 20 or #lines
+
+  -- find csprojects and foreach
+
+  win.refreshLines()
 end
 
 return M

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -1,0 +1,133 @@
+local M = {}
+
+local file_template = [[
+//v1
+#r "nuget: Newtonsoft.Json"
+
+open System
+open System.IO
+open System.Xml
+open Newtonsoft.Json.Linq
+open Newtonsoft.Json
+
+let xmlToJson (xml: string) : JObject =
+    // Load the XML string into an XmlDocument
+    let xmlDoc = new XmlDocument()
+    xmlDoc.LoadXml(xml)
+    // Convert the XmlDocument to JSON and parse it into a JObject
+    let jsonString = JsonConvert.SerializeXmlNode(xmlDoc, Newtonsoft.Json.Formatting.Indented)
+    JObject.Parse(jsonString)
+
+let extractResults (jsonObj: JObject) : JObject option =
+    // Extract the "Results" object from the JSON object
+    jsonObj.SelectToken("$.TestRun.Results") :?> JObject |> Option.ofObj
+
+let main (argv: string[]) =
+    if argv.Length <> 1 then
+        printfn "Usage: fsi script.fsx <xml-file-path>"
+        1
+    else
+        try
+            let filePath = argv.[0]
+            if File.Exists(filePath) then
+                let xmlContent = File.ReadAllText(filePath)
+                let jsonObj = xmlToJson(xmlContent)
+                match extractResults(jsonObj) with
+                | Some results ->
+                    printfn "%s" (results.ToString(Formatting.Indented))
+                    0
+                | None ->
+                    printfn "Error: 'Results' object not found in the JSON output."
+                    1
+            else
+                printfn "Error: File not found - %s" filePath
+                1
+        with
+        | :? System.Exception as ex ->
+            printfn "Error: %s" ex.Message
+            1
+
+main fsi.CommandLineArgs.[1..]
+]]
+
+local ensure_and_get_fsx_path = function()
+  local dir = vim.fs.joinpath(vim.fn.stdpath("data"), "easy-dotnet")
+  local file_utils = require("easy-dotnet.file-utils")
+  file_utils.ensure_directory_exists(dir)
+  local filepath = vim.fs.joinpath(dir, "test_parser.fsx")
+  local file = io.open(filepath, "r")
+  if file then
+    file:close()
+  else
+    file = io.open(filepath, "w")
+    if file == nil then
+      print("Failed to create the file: " .. filepath)
+      return
+    end
+    file:write(file_template)
+
+    file:close()
+  end
+
+  return filepath
+end
+
+--- @class TestResult
+--- @field UnitTestResult TestCase[]
+
+--- @class TestCase
+--- @field ["@executionId"] string
+--- @field ["@testId"] string
+--- @field ["@testName"] string
+--- @field ["@computerName"] string
+--- @field ["@duration"] string
+--- @field ["@startTime"] string
+--- @field ["@endTime"] string
+--- @field ["@testType"] string
+--- @field ["@outcome"] string
+--- @field ["@testListId"] string
+--- @field ["@relativeResultsDirectory"] string
+--- @field Output Output
+
+--- @class Output
+--- @field ErrorInfo? ErrorInfo
+--- @field StdOut? string
+
+--- @class ErrorInfo
+--- @field Message string
+--- @field StackTrace string
+
+---@param xml_path string
+M.xml_to_json = function(xml_path, cb)
+  local fsx_file = ensure_and_get_fsx_path()
+  local command = string.format("dotnet fsi %s '%s'", fsx_file, xml_path)
+
+
+  vim.fn.jobstart(command, {
+    stdout_buffered = true,
+    ---@param data string[]
+    on_stdout = function(_, data)
+      local output = table.concat(data)
+      local pos = output:find("{")
+
+      if pos == nil then
+        require("easy-dotnet.debug").write_to_log(output)
+        error("Invalid json returned from fsx script")
+      end
+
+      ---@type TestResult
+      local test_summary = vim.fn.json_decode(output:sub(pos))
+
+      cb(test_summary.UnitTestResult)
+    end,
+    on_exit = function(_, code)
+      if code ~= 0 then
+        vim.notify("Command failed with exit code: " .. code, vim.log.levels.ERROR)
+        return {}
+      end
+    end
+  })
+end
+
+
+return M

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -72,9 +72,7 @@ main fsi.CommandLineArgs.[1..]
 ]]
 
 local ensure_and_get_fsx_path = function()
-  local dir = vim.fs.joinpath(vim.fn.stdpath("data"), "easy-dotnet")
-  local file_utils = require("easy-dotnet.file-utils")
-  file_utils.ensure_directory_exists(dir)
+  local dir = require("easy-dotnet.constants").get_data_directory()
   local filepath = vim.fs.joinpath(dir, "test_parser.fsx")
   local file = io.open(filepath, "r")
   if file then

--- a/lua/easy-dotnet/test-runner/window.lua
+++ b/lua/easy-dotnet/test-runner/window.lua
@@ -1,0 +1,130 @@
+local Window = {}
+Window.__index = Window
+
+local function get_default_win_opts()
+  local width = math.floor(vim.o.columns / 2) - 2
+  local height = 20
+  return {
+    relative = "editor",
+    width = width,
+    height = height,
+    col = math.floor((vim.o.columns - width) / 2),
+    row = math.floor((vim.o.lines - height) / 2),
+    style = "minimal",
+    border = "rounded"
+  }
+end
+
+local function update_win_opts(win, opts)
+  if win == nil then
+    return
+  end
+  vim.api.nvim_win_set_config(win, opts)
+end
+
+
+function Window.new_float()
+  local self = setmetatable({}, Window)
+  self.buf = vim.api.nvim_create_buf(false, true)
+  self.opts = get_default_win_opts()
+  self.buf_opts = {
+    modifiable = false,
+    filetype = nil
+  }
+  self.callbacks = {}
+  return self
+end
+
+function Window:buf_set_filetype(filetype)
+  if self.buf ~= nil then
+    vim.api.nvim_set_option_value('filetype', filetype, { buf = self.buf })
+  end
+
+  self.buf_opts.filetype = filetype
+  return self
+end
+
+function Window:on_win_close(callback)
+  if self.win == nil then
+    table.insert(self.callbacks, callback)
+    return self
+  end
+
+  vim.api.nvim_create_autocmd("WinClosed", {
+    callback = function(event)
+      if tonumber(event.match) == self.win then
+        callback()
+      end
+    end
+  })
+
+  return self
+end
+
+local function set_buf_opts(buf, opts)
+  vim.api.nvim_set_option_value('filetype', opts.filetype, { buf = buf })
+  vim.api.nvim_set_option_value('modifiable', opts.modifiable, { buf = buf })
+end
+
+function Window:write_buf(lines)
+  vim.api.nvim_set_option_value('modifiable', true, { buf = self.buf })
+  vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, lines)
+  set_buf_opts(self.buf, self.buf_opts)
+  return self
+end
+
+function Window:close()
+  vim.api.nvim_win_close(self.win, true)
+end
+
+function Window:pos_left()
+  self.opts.col = 1
+  update_win_opts(self.win, self.opts)
+  return self
+end
+
+function Window:pos_right()
+  self.opts.col = self.opts.width + 2
+  update_win_opts(self.win, self.opts)
+  return self
+end
+
+function Window:pos_center()
+  self.opts.col = math.floor((vim.o.columns - self.opts.width) / 2)
+  update_win_opts(self.win, self.opts)
+  return self
+end
+
+function Window:link_close(float)
+  self:on_win_close(function()
+    float:close()
+  end)
+  float:on_win_close(function()
+    self:close()
+  end)
+  return self
+end
+
+function Window:create()
+  local win = vim.api.nvim_open_win(self.buf, true, self.opts)
+  self.win = win
+
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_win_close(self.win, true)
+  end, { buffer = self.buf, noremap = true, silent = true })
+
+  set_buf_opts(self.buf, self.buf_opts)
+
+  vim.api.nvim_create_autocmd("WinClosed", {
+    callback = function(event)
+      if tonumber(event.match) == win then
+        for _, cb in ipairs(self.callbacks) do
+          cb()
+        end
+      end
+    end
+  })
+  return self
+end
+
+return Window


### PR DESCRIPTION
Trying to give the testrunner a cleaner look, today its very "distracting". I want to use more subtle higlight groups and make it intuitive without explicitly spamming "❌" emojis etc..

Features

- [x] Show solution as root group
- [x] Show csprojects
- [x] Strip namespaces for cleaner look
- [x] Add highlights to sln and project for cleaner look
- [x] Testrunner shows solution and csprojects as default when opening
- [x] Peek stacktrace now opens the file in a floating buffer, indicating the offending line
- [x] Uses F# script to parse xml to json for test result parsing
- [x] Testrun results now gets parsed from xmlfile in TestResults folder rather than from stdout
- [x] ClassData and inline data should be grouped under a new form of group


Issues

- [x] ~Dotnet test -t runs synchronously causing major freeze~
- [x] ~Tests using inline data is not matched correctly when updating status~
- [x] ~Identical namespaces across projects causes issues in status reporting when running solution~
- [x] ~Status aggregation on namespaces/csproject before all tests have finished ruins highlight, given wrong indication~
- [x] ~Tests using inline data is not matched correctly when updating status~
- [x] ~Exclude test projects with no tests~
- [x] ~`Workload updates are available` gets accidently parsed as a test~
- [ ] An error will occur if the json output from the xml file is too large. Apparantly vim.fn.json_decode has a rather low max character limit (this can be solved in the f# script by splitting the output into multiple files)

When running dotnet test on the solution it seems hard to differentiate which tests belongs to which project, solved for now by just running a for loop on the projects in the solution and running in parallel. Uncertain which consequences this will have


## Memory issues with Xml

Initially when testing on a rather small group of tests in a project I ran into memory issues when using vim.fn.json_decode on the converted json. I modified the F# script to remove a lot of unused fields from the outputted json, but I can still imagine that a csproject could potentially have 1000+ tests. Which is guaranteed to crash the vim.fn.json_decode execution. Essentially we are only interested in 3 properties for each unit_test result. `testName`, `outcome` and stacktrace(if failed).

## Option 1

Remove the stacktrace and only output a list of testname and outcome, this would almost guarantee no memory issues for the user. When the peek_stack_trace is called it will either have to re-parse the entire xml or modify the f# script to write all stacktraces to separate files in the initial parsing.


## Option 2

Paginate the json, set an arbitrary size and write a "nextPage" property after x amount of items.
This would result in modifying the F# script to parse the xml, chunk the json and output it into one or more files.

## Option 3

Slice the stacktrace to only get the root "error" and the file name and line number. (temporary fix)


![image](https://github.com/user-attachments/assets/26768128-9561-4e90-a98c-54992d2c4e31)




Peek stacktrace now opens the offending file with virt text to highlight colors
![image](https://github.com/user-attachments/assets/583a67ff-1377-439c-81ce-d71f8f8320f5)


## Test findings

### Duplicate testnames without namespaces within same csproject
I hope this is not a common thing cause i have no idea how to fix it
This seems to be caused by the [TestMethod] attribute. When this attribute is used dotnet test -t will not include the namespace only the name of the test. This is specific to MSTest. 

Support for MSTest might be harder to achieve