### PR TITLE
feat: add is_dotnet_project() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ dotnet.build_quickfix()                     -- Build dotnet project and open bui
 dotnet.build_default_quickfix()             -- Will build the last selected project and open build errors in quickfix list
 dotnet.clean()                              -- Run dotnet clean in the project
 dotnet.get_debug_dll()                      -- Return the dll from the bin/debug folder
+dotnet.is_dotnet_project()                  -- Returns true if a csproject or sln file is present in cwd or some folders down
 ```
 
 ### Vim commands

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -119,4 +119,10 @@ end
 M.get_debug_dll = debug.get_debug_dll
 M.get_environment_variables = debug.get_environment_variables
 
+M.is_dotnet_project = function()
+  local project_files = require("easy-dotnet.parsers.sln-parse").find_solution_file() or
+      require("easy-dotnet.parsers.csproj-parse").find_csproj_file()
+  return project_files ~= nil
+end
+
 return M


### PR DESCRIPTION
Adds a dotnet.is_dotnet_project() function to check whether cwd or its subfolders contain a csproject or sln file
fixes: #70 