### PR TITLE
feat(testrunner): test discovery using vstest native code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
     local dotnet = require("easy-dotnet")
     -- Options are not required
     dotnet.setup({
+      --Optional function to return the path for the dotnet sdk (e.g C:/ProgramFiles/dotnet/sdk/8.0.0)
+      get_sdk_path = get_sdk_path,
       test_runner = {
         noBuild = true,
         noRestore = true,

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Integrated test runner inspired by Rider IDE
 - `<leader>p` -> Peek stacktrace on failed test
 - `<leader>fe` -> Show only failed tests
 - `<leader>gf` -> Go to file (only works inside stacktrace float)
+- `g` -> Go to file
 
 ## Outdated
 

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -42,7 +42,7 @@ M.setup = function(opts)
       actions.build(merged_opts.terminal, false)
     end,
     testrunner = function()
-      require("easy-dotnet.test-runner.runner").runner(merged_opts.test_runner)
+      require("easy-dotnet.test-runner.runner").runner(merged_opts.test_runner, merged_opts.get_sdk_path())
     end,
     outdated = function()
       require("easy-dotnet.outdated.outdated").outdated()

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -1,6 +1,7 @@
 ---@class TestRunnerOptions
 ---@field noBuild boolean
 ---@field noRestore boolean
+---@field vstest_path string | nil
 
 local function get_secret_path(secret_guid)
   local path = ""
@@ -45,6 +46,7 @@ return {
   test_runner = {
     noBuild = true,
     noRestore = true,
+    vstest_path = nil
   },
   csproj_mappings = true,
   auto_bootstrap_namespace = true

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -1,7 +1,14 @@
 ---@class TestRunnerOptions
 ---@field noBuild boolean
 ---@field noRestore boolean
----@field vstest_path string | nil
+
+local function get_sdk_path()
+  local sdk_version = vim.system({ "dotnet", "--version" }):wait().stdout:gsub("\r", ""):gsub("\n", "")
+  local isWindows = require("easy-dotnet.extensions").isWindows()
+  local base = isWindows and "C:/Program Files/dotnet/sdk" or "/usr/lib/dotnet/sdk"
+  local sdk_path = vim.fs.joinpath(base, sdk_version)
+  return sdk_path
+end
 
 local function get_secret_path(secret_guid)
   local path = ""
@@ -18,6 +25,8 @@ local function get_secret_path(secret_guid)
 end
 
 return {
+  ---@type function | string
+  get_sdk_path = get_sdk_path,
   ---@param path string
   ---@param action "test"|"restore"|"build"|"run"
   terminal = function(path, action)
@@ -46,7 +55,6 @@ return {
   test_runner = {
     noBuild = true,
     noRestore = true,
-    vstest_path = nil
   },
   csproj_mappings = true,
   auto_bootstrap_namespace = true

--- a/lua/easy-dotnet/test-runner/discovery.lua
+++ b/lua/easy-dotnet/test-runner/discovery.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.script_template = [[
+//v2
 #r "nuget: Microsoft.TestPlatform.TranslationLayer, 17.11.0"
 #r "nuget: Microsoft.VisualStudio.TestPlatform, 14.0.0"
 #r "nuget: MSTest.TestAdapter, 3.3.1"
@@ -24,8 +25,10 @@ module TestDiscovery =
               let testCases = Seq.toList discoveredTestCases
               if testCases |> List.isEmpty |> not then
                   let tests = testCases |> List.map (fun s -> { Id = s.Id; Namespace = s.FullyQualifiedName; Name = s.DisplayName; FilePath = s.CodeFilePath; Linenumber = s.LineNumber })
-                  let json = JsonConvert.SerializeObject(tests, Formatting.Indented)
-                  Console.WriteLine(json)
+                  for test in tests do
+                    let json = JsonConvert.SerializeObject(test, Formatting.None)
+                    printfn "%s" (json.ToString())
+
               else
                   ()
           member _.HandleDiscoveryComplete(_: DiscoveryCompleteEventArgs, _: IEnumerable<TestCase>): unit =

--- a/lua/easy-dotnet/test-runner/discovery.lua
+++ b/lua/easy-dotnet/test-runner/discovery.lua
@@ -1,0 +1,94 @@
+local M = {}
+
+M.script_template = [[
+#r "nuget: Microsoft.TestPlatform.TranslationLayer, 17.11.0"
+#r "nuget: Microsoft.VisualStudio.TestPlatform, 14.0.0"
+#r "nuget: MSTest.TestAdapter, 3.3.1"
+#r "nuget: MSTest.TestFramework, 3.3.1"
+#r "nuget: Newtonsoft.Json, 13.0.3"
+
+open Microsoft.TestPlatform.VsTestConsole.TranslationLayer
+open Microsoft.VisualStudio.TestPlatform.ObjectModel
+open Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
+open System
+open System.Collections.Generic
+open Newtonsoft.Json
+
+module TestDiscovery =
+
+    type Test = { Id: Guid; Namespace: string; Name: string; FilePath: string; Linenumber: int }
+
+    type PlaygroundTestDiscoveryHandler() =
+        interface ITestDiscoveryEventsHandler2 with
+          member _.HandleDiscoveredTests(discoveredTestCases: IEnumerable<TestCase>) =
+              let testCases = Seq.toList discoveredTestCases
+              if testCases |> List.isEmpty |> not then
+                  let tests = testCases |> List.map (fun s -> { Id = s.Id; Namespace = s.FullyQualifiedName; Name = s.DisplayName; FilePath = s.CodeFilePath; Linenumber = s.LineNumber })
+                  let json = JsonConvert.SerializeObject(tests, Formatting.Indented)
+                  Console.WriteLine(json)
+              else
+                  ()
+          member _.HandleDiscoveryComplete(_: DiscoveryCompleteEventArgs, _: IEnumerable<TestCase>): unit =
+              ()
+          member _.HandleLogMessage(_: Logging.TestMessageLevel, _: string): unit =
+              ()
+          member _.HandleRawMessage(_: string): unit =
+              ()
+
+
+    type TestSessionHandler() =
+      let mutable testSessionInfo: TestSessionInfo option = None
+
+      interface ITestSessionEventsHandler with
+        member _.HandleStartTestSessionComplete(eventArgs: StartTestSessionCompleteEventArgs) =
+            testSessionInfo <- Some(eventArgs.TestSessionInfo)
+        member _.HandleLogMessage(_: Logging.TestMessageLevel, _: string): unit =
+            ()
+        member _.HandleRawMessage(_: string): unit =
+            ()
+        member _.HandleStopTestSessionComplete(_: StopTestSessionCompleteEventArgs): unit =
+            ()
+
+      member _.TestSessionInfo
+        with get() = testSessionInfo
+        and set(value) = testSessionInfo <- value
+
+    let main(argv: string[]) =
+      if argv.Length <> 2 then
+        printfn "Usage: fsi script.fsx <vstest-console-path> <test-dll-path>"
+        1
+      else
+        let console = argv.[0]
+
+        let sourceSettings = """
+            <RunSettings>
+            </RunSettings>
+            """
+
+        let sources = argv.[1..]
+
+        let environmentVariables = Dictionary<string, string>()
+        environmentVariables.Add("VSTEST_CONNECTION_TIMEOUT", "999")
+        environmentVariables.Add("VSTEST_DEBUG_NOBP", "1")
+        environmentVariables.Add("VSTEST_RUNNER_DEBUG_ATTACHVS", "0")
+        environmentVariables.Add("VSTEST_HOST_DEBUG_ATTACHVS", "0")
+        environmentVariables.Add("VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS", "0")
+
+        let options = TestPlatformOptions(CollectMetrics = true)
+
+        let r = VsTestConsoleWrapper(console, ConsoleParameters(EnvironmentVariables = environmentVariables))
+        let sessionHandler = TestSessionHandler()
+        let discoveryHandler = PlaygroundTestDiscoveryHandler()
+        let testSession =
+          match sessionHandler.TestSessionInfo with
+          | Some info -> info
+          | None ->
+              new TestSessionInfo()
+
+        r.DiscoverTests(sources, sourceSettings, options, testSession, discoveryHandler)
+        0
+
+    main fsi.CommandLineArgs.[1..]
+]]
+
+return M

--- a/lua/easy-dotnet/test-runner/discovery.lua
+++ b/lua/easy-dotnet/test-runner/discovery.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local script_template = [[
-//v3
+//v1
 #r "nuget: Microsoft.TestPlatform.TranslationLayer, 17.11.0"
 #r "nuget: Microsoft.VisualStudio.TestPlatform, 14.0.0"
 #r "nuget: MSTest.TestAdapter, 3.3.1"

--- a/lua/easy-dotnet/test-runner/discovery.lua
+++ b/lua/easy-dotnet/test-runner/discovery.lua
@@ -26,7 +26,7 @@ module TestDiscovery =
               if testCases |> List.isEmpty |> not then
                   let tests = testCases |> List.map (fun s -> { Id = s.Id; Namespace = s.FullyQualifiedName; Name = s.DisplayName; FilePath = s.CodeFilePath; Linenumber = s.LineNumber })
                   for test in tests do
-                    let json = JsonConvert.SerializeObject(test, Formatting.None)
+                    let json = JsonConvert.SerializeObject(test, Formatting.None).Replace("\n", "").Replace("\r", "")
                     printfn "%s" (json.ToString())
 
               else

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -101,7 +101,7 @@ local function run_test_group(line, win)
   local suite_name = line.namespace
   for _, test_line in ipairs(win.lines) do
     if line.name == test_line.name:gsub("%b()", "") and line.cs_project_path == test_line.cs_project_path and line.solution_file_path == test_line.solution_file_path then
-      table.insert(matches, { ref = test_line, line = test_line.namespace, id = line.id })
+      table.insert(matches, { ref = test_line, line = test_line.namespace, id = test_line.id })
       test_line.icon = "<Running>"
     end
   end

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -314,6 +314,17 @@ local keymaps = {
   ["<leader>fe"] = function(_, _, win)
     filter_failed_tests(win)
   end,
+  ---@param line Test
+  ["g"] = function(_, line, win)
+    if line.type == "test" or line.type == "subcase" or line.type == "test_group" then
+      if line.file_path ~= nil then
+        vim.cmd("edit " .. line.file_path)
+        vim.api.nvim_win_set_cursor(0, { line.line_number and (line.line_number - 1) or 0, 0 })
+      end
+    else
+      vim.notify("Cant go to " .. line.type)
+    end
+  end,
   ["E"] = function(_, _, win)
     for _, value in ipairs(win.lines) do
       value.hidden = false

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -50,13 +50,14 @@ local function parse_log_file(relative_log_file_path, win, matches)
       for _, match in ipairs(matches) do
         local test_line = match.ref
         if test_line.type == "test" or test_line.type == "subcase" then
-          local result = unit_test_results[match.id]
-          if result == nil then
-            error(string.format("Status of %s was not present in xml file", match.ref.name))
+          for _, value in ipairs(unit_test_results) do
+            if match.id == value.id then
+              parse_status(value, test_line)
+            end
           end
-          parse_status(result, test_line)
         end
       end
+
       aggregateStatus(matches)
       win.refreshLines()
     end)
@@ -209,7 +210,7 @@ local function run_test(line, win)
         require("easy-dotnet.test-runner.test-parser").xml_to_json(relative_log_file_path,
           ---@param unit_test_results TestCase
           function(unit_test_results)
-            local result = unit_test_results[line.id]
+            local result = unit_test_results[1]
             if result == nil then
               error(string.format("Status of %s was not present in xml file", line.name))
             end

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -50,7 +50,6 @@ local function parse_log_file(relative_log_file_path, win, matches)
       for _, match in ipairs(matches) do
         local test_line = match.ref
         if test_line.type == "test" or test_line.type == "subcase" then
-          --TODO: match id instead
           local result = unit_test_results[match.id]
           if result == nil then
             error(string.format("Status of %s was not present in xml file", match.ref.name))

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -151,44 +151,14 @@ local default_options = require("easy-dotnet.options").test_runner
 --- @field file_path string | nil
 --- @field line_number number | nil
 
-local ensure_and_get_fsx_path = function()
-  local file_template = require("easy-dotnet.test-runner.discovery").script_template
-  local dir = require("easy-dotnet.constants").get_data_directory()
-  local filepath = vim.fs.joinpath(dir, "test_discovery.fsx")
-  local file = io.open(filepath, "r")
-  if file then
-    local v = file:read("l"):match("//v(%d+)")
-    file:close()
-    local new_v = file_template:match("//v(%d+)")
-    if v ~= new_v then
-      local overwrite_file = io.open(filepath, "w+")
-      if overwrite_file == nil then
-        error("Failed to create the file: " .. filepath)
-      end
-      vim.notify("Updating test_discovery.fsx", vim.log.levels.INFO)
-      overwrite_file:write(file_template)
-      overwrite_file:close()
-    end
-  else
-    file = io.open(filepath, "w")
-    if file == nil then
-      print("Failed to create the file: " .. filepath)
-      return
-    end
-    file:write(file_template)
-
-    file:close()
-  end
-
-  return filepath
-end
 
 ---@param project Test
 ---@param options TestRunnerOptions
 local function discover_tests_for_project_and_update_lines(project, win, options, dll_path)
   local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dll_path)
   local outfile = os.tmpname()
-  local command = string.format("dotnet fsi %s '%s' '%s' '%s'", ensure_and_get_fsx_path(), options.vstest_path,
+  local script_path = require("easy-dotnet.test-runner.discovery").get_script_path()
+  local command = string.format("dotnet fsi %s '%s' '%s' '%s'", script_path, options.vstest_path,
     absolute_dll_path, outfile)
 
   local tests = {}

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -154,11 +154,13 @@ local default_options = require("easy-dotnet.options").test_runner
 
 ---@param project Test
 ---@param options TestRunnerOptions
-local function discover_tests_for_project_and_update_lines(project, win, options, dll_path)
+---@param sdk_path string
+local function discover_tests_for_project_and_update_lines(project, win, options, dll_path, sdk_path)
+  local vstest_dll = vim.fs.joinpath(sdk_path, "vstest.console.dll")
   local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dll_path)
   local outfile = os.tmpname()
   local script_path = require("easy-dotnet.test-runner.discovery").get_script_path()
-  local command = string.format("dotnet fsi %s '%s' '%s' '%s'", script_path, options.vstest_path,
+  local command = string.format("dotnet fsi %s '%s' '%s' '%s'", script_path, vstest_dll,
     absolute_dll_path, outfile)
 
   local tests = {}
@@ -240,7 +242,7 @@ local function discover_tests_for_project_and_update_lines(project, win, options
   })
 end
 
-M.runner = function(options)
+M.runner = function(options, sdk_path)
   ---@type TestRunnerOptions
   local mergedOpts = merge_tables(default_options, options or {})
   local sln_parse = require("easy-dotnet.parsers.sln-parse")
@@ -309,7 +311,7 @@ M.runner = function(options)
         expand = {},
         highlight = "Character"
       }
-      discover_tests_for_project_and_update_lines(project, win, mergedOpts, value.dll_path)
+      discover_tests_for_project_and_update_lines(project, win, mergedOpts, value.dll_path, sdk_path)
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -235,12 +235,14 @@ local function discover_tests_for_project_and_update_lines(project, win, options
         ---@type Test[]
         local converted = {}
         for _, value in ipairs(tests) do
+          --HACK: This is necessary for MSTest cases where name is not a namespace.classname but rather classname
+          local name = value.Name:find("%.") and value.Name or value.Namespace
           ---@type Test
           local test = {
             id = value.Id,
-            name = value.Name,
-            full_name = value.Name,
-            namespace = value.Name,
+            name = name,
+            full_name = name,
+            namespace = name,
             file_path = value.FilePath,
             line_number = value.Linenumber,
             preIcon = "",

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -26,6 +26,7 @@ end
 
 ---@param tests Test[]
 local function expand_test_names_with_flags(tests)
+  local offset_indent = 2
   ---@type Test[]
   local expanded = {}
   local seen = {}
@@ -73,7 +74,7 @@ local function expand_test_names_with_flags(tests)
           namespace = concatenated,
           value = part,
           is_full_path = is_full_path and not has_arguments,
-          indent = (current_count * 2) - 1,
+          indent = (current_count * 2) - 1 + offset_indent,
           preIcon = is_full_path == false and "📂" or has_arguments and "📦" or "🧪",
           type = is_full_path == false and "namespace" or has_arguments and "test_group" or "test",
           line_number = is_full_path and test.line_number or nil,
@@ -93,7 +94,7 @@ local function expand_test_names_with_flags(tests)
         name = full_test_name:match("([^.]+%b())$"),
         full_name = test.full_name,
         is_full_path = true,
-        indent = (segment_count * 2),
+        indent = (segment_count * 2) + offset_indent,
         preIcon = "🧪",
         type = "subcase",
         collapsable = false,
@@ -171,16 +172,12 @@ local ensure_and_get_fsx_path = function()
 end
 
 
----@return Test[]
 ---@param project Test
 ---@param options TestRunnerOptions
 local function discover_tests_for_project_and_update_lines(project, win, options, dll_path)
   local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dll_path)
-  local script_path = ensure_and_get_fsx_path()
-  local vstest_path = options.vstest_path
-
-  local command = string.format("dotnet fsi %s '%s' '%s'", script_path, vstest_path, absolute_dll_path)
-
+  local command = string.format("dotnet fsi %s '%s' '%s'", ensure_and_get_fsx_path(), options.vstest_path,
+    absolute_dll_path)
 
   vim.fn.jobstart(command, {
     stdout_buffered = true,

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -177,7 +177,6 @@ end
 local function discover_tests_for_project_and_update_lines(project, win, options, dll_path)
   local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dll_path)
   local script_path = ensure_and_get_fsx_path()
-  vim.notify(options.vstest_path)
   local vstest_path = options.vstest_path
 
   local command = string.format("dotnet fsi %s '%s' '%s'", script_path, vstest_path, absolute_dll_path)

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local file_template = [[
-//v3
+//v2
 #r "nuget: Newtonsoft.Json"
 open System
 open System.IO

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -17,7 +17,7 @@ let xmlToJson (xml: string) : JObject =
 
 let transformTestCase (testCase: JObject) : JProperty =
     let testName = testCase.["@testName"].ToString()
-    let testId = testCase.["@id"].ToString()
+    let testId = testCase.["@testId"].ToString()
     let newTestCase = new JObject()
     newTestCase.["outcome"] <- testCase.["@outcome"]
 

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -17,6 +17,7 @@ let xmlToJson (xml: string) : JObject =
 
 let transformTestCase (testCase: JObject) : JProperty =
     let testName = testCase.["@testName"].ToString()
+    let testId = testCase.["@id"].ToString()
     let newTestCase = new JObject()
     newTestCase.["outcome"] <- testCase.["@outcome"]
 
@@ -24,7 +25,7 @@ let transformTestCase (testCase: JObject) : JProperty =
     if errorInfo <> null && errorInfo.["StackTrace"] <> null then
         newTestCase.["stackTrace"] <- errorInfo.["StackTrace"]
 
-    new JProperty(testName, newTestCase)
+    new JProperty(testId, newTestCase)
 
 let extractAndTransformResults (jsonObj: JObject) : JObject option =
     let resultsToken = jsonObj.SelectToken("$.TestRun.Results.UnitTestResult")
@@ -102,9 +103,10 @@ M.xml_to_json = function(xml_path, cb)
   local fsx_file = ensure_and_get_fsx_path()
   local command = string.format("dotnet fsi %s '%s'", fsx_file, xml_path)
 
-
   vim.fn.jobstart(command, {
     stdout_buffered = true,
+    on_stderr = function(_, data)
+    end,
     ---@param data string[]
     on_stdout = function(_, data)
       local output = table.concat(data)

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local file_template = [[
-//v1
+//v2
 #r "nuget: Newtonsoft.Json"
 open System
 open System.IO
@@ -77,7 +77,18 @@ local ensure_and_get_fsx_path = function()
   local filepath = vim.fs.joinpath(dir, "test_parser.fsx")
   local file = io.open(filepath, "r")
   if file then
+    local v = file:read("l"):match("//v(%d+)")
     file:close()
+    local new_v = file_template:match("//v(%d+)")
+    if v ~= new_v then
+      local overwrite_file = io.open(filepath, "w+")
+      if overwrite_file == nil then
+        error("Failed to create the file: " .. filepath)
+      end
+      vim.notify("Updating test_parser.fsx", vim.log.levels.INFO)
+      overwrite_file:write(file_template)
+      overwrite_file:close()
+    end
   else
     file = io.open(filepath, "w")
     if file == nil then


### PR DESCRIPTION
## Description
Uses vstest and F# instead of `dotnet test -t` for test discovery, this fixes a lot of bugs and brings a lot of enhancements.

## Features:
- [x] Fixes MSTest discovery issues
- [x] Better lookup on testresults using Id instead of fully qualified name
- [x] F# scripts will update automatically when installing new versions of easy-dotnet.nvim
- [x] Automatically resolve sdk path

## Issues:
- [x] Requires an absolute vstest.console path to work (ships with dotnet sdk confirmed)
- [x] Test on linux
- [x] Replace old test parser with new programatically
- [x] Value too large (partition json with F#)
- [x] Update readme (how to find sdk path etc..)
- [x] Add check if name doesnt contain . and use namespace instead (or merge name and namespace) (MSTest specific)
