### PR TITLE
Fixed issue running testrunner when opts is not set

### DIFF
--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -42,7 +42,7 @@ M.setup = function(opts)
       actions.build(merged_opts.terminal, false)
     end,
     testrunner = function()
-      require("easy-dotnet.test-runner.runner").runner(opts.test_runner)
+      require("easy-dotnet.test-runner.runner").runner(merged_opts.test_runner)
     end,
     outdated = function()
       require("easy-dotnet.outdated.outdated").outdated()


### PR DESCRIPTION
I ran into a problem when setting everything up for the first time where I couldn't open the test runner. This commit fixes that issue