### PR TITLE
feat: basic F# support

### DIFF
--- a/lua/easy-dotnet/actions/build.lua
+++ b/lua/easy-dotnet/actions/build.lua
@@ -36,7 +36,7 @@ end
 
 
 local function csproj_fallback(term)
-  local csproj_path = csproj_parse.find_csproj_file()
+  local csproj_path = csproj_parse.find_project_file()
   if (csproj_path == nil) then
     vim.notify(error_messages.no_project_definition_found)
     return
@@ -104,7 +104,7 @@ M.build_project_quickfix = function(use_default, dotnet_args)
 
   local solutionFilePath = sln_parse.find_solution_file()
   if solutionFilePath == nil then
-    local csproj = csproj_parse.find_csproj_file()
+    local csproj = csproj_parse.find_project_file()
     if csproj == nil then
       vim.notify(messages.no_project_definition_found)
     end
@@ -145,7 +145,7 @@ end
 
 
 M.build_solution = function(term)
-  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
+  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_project_file()
   if solutionFilePath == nil then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/actions/clean.lua
+++ b/lua/easy-dotnet/actions/clean.lua
@@ -6,7 +6,7 @@ local error_messages = require("easy-dotnet.error-messages")
 
 
 M.clean_solution = function()
-  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
+  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_project_file()
   if solutionFilePath == nil then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -147,10 +147,24 @@ local projects = {
     end
   },
   {
+    display = "ASP.NET Core Web API F#",
+    type = "project",
+    run = function(name)
+      create_and_link_project(name, "webapi --language F#")
+    end
+  },
+  {
     display = "ASP.NET Core Empty",
     type = "project",
     run = function(name)
       create_and_link_project(name, "web")
+    end
+  },
+  {
+    display = "ASP.NET Core Empty F#",
+    type = "project",
+    run = function(name)
+      create_and_link_project(name, "web --language F#")
     end
   },
   {
@@ -168,10 +182,24 @@ local projects = {
     end
   },
   {
+    display = "Console app F#",
+    type = "project",
+    run = function(name)
+      create_and_link_project(name, "console --language F#")
+    end
+  },
+  {
     display = "Class library",
     type = "project",
     run = function(name)
       create_and_link_project(name, "classlib")
+    end
+  },
+  {
+    display = "Class library F#",
+    type = "project",
+    run = function(name)
+      create_and_link_project(name, "classlib --language F#")
     end
   },
   {

--- a/lua/easy-dotnet/actions/restore.lua
+++ b/lua/easy-dotnet/actions/restore.lua
@@ -6,7 +6,7 @@ local error_messages = require("easy-dotnet.error-messages")
 
 ---@param term function
 M.restore = function(term)
-  local project = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
+  local project = sln_parse.find_solution_file() or csproj_parse.find_project_file()
   if project == nil then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/actions/run.lua
+++ b/lua/easy-dotnet/actions/run.lua
@@ -8,7 +8,7 @@ local error_messages = require("easy-dotnet.error-messages")
 
 ---@param term function
 local function csproj_fallback(term)
-  local csproj_path = csproj_parse.find_csproj_file()
+  local csproj_path = csproj_parse.find_project_file()
   if (csproj_path == nil) then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/actions/test.lua
+++ b/lua/easy-dotnet/actions/test.lua
@@ -7,7 +7,7 @@ local sln_parse = parsers.sln_parser
 local error_messages = require("easy-dotnet.error-messages")
 
 local function csproj_fallback(on_select)
-  local csproj_path = csproj_parse.find_csproj_file()
+  local csproj_path = csproj_parse.find_project_file()
   if (csproj_path == nil) then
     vim.notify("No .sln file or .csproj file found")
   end
@@ -62,7 +62,7 @@ M.run_test_picker = function(on_select, use_default)
 end
 
 M.test_solution = function(term)
-  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
+  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_project_file()
   if solutionFilePath == nil then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/default-manager.lua
+++ b/lua/easy-dotnet/default-manager.lua
@@ -1,4 +1,4 @@
----@class Project
+---@class DotnetProject
 ---@field name string
 ---@field path string
 
@@ -50,7 +50,7 @@ end
 ---Checks for the default project in the solution file.
 ---@param solution_file_path string Path to the solution file.
 ---@param type '"build"' | '"test"' | '"run"'
----@return Project|nil
+---@return DotnetProject|nil
 M.check_default_project = function(solution_file_path, type)
   local file = get_or_create_cache_file(solution_file_path)
   local sln_parse = require("easy-dotnet.parsers.sln-parse")
@@ -70,7 +70,7 @@ M.check_default_project = function(solution_file_path, type)
 end
 
 ---Sets the default project in the solution file.
----@param project Project The project to set as default.
+---@param project DotnetProject The project to set as default.
 ---@param solution_file_path string Path to the solution file.
 ---@param type '"build"' | '"test"' | '"run"'
 M.set_default_project = function(project, solution_file_path, type)

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -125,7 +125,7 @@ M.get_environment_variables = debug.get_environment_variables
 
 M.is_dotnet_project = function()
   local project_files = require("easy-dotnet.parsers.sln-parse").find_solution_file() or
-      require("easy-dotnet.parsers.csproj-parse").find_csproj_file()
+      require("easy-dotnet.parsers.csproj-parse").find_project_file()
   return project_files ~= nil
 end
 

--- a/lua/easy-dotnet/secrets.lua
+++ b/lua/easy-dotnet/secrets.lua
@@ -66,7 +66,7 @@ local init_secrets = function(project_file_path, get_secret_path)
 end
 
 local function csproj_fallback(get_secret_path)
-  local csproj_path = csproj_parse.find_csproj_file()
+  local csproj_path = csproj_parse.find_project_file()
   if (csproj_path == nil) then
     vim.notify(error_messages.no_project_definition_found)
     return

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -249,7 +249,7 @@ M.runner = function(options, sdk_path)
   local csproj_parse = require("easy-dotnet.parsers.csproj-parse")
   local error_messages = require("easy-dotnet.error-messages")
 
-  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_csproj_file()
+  local solutionFilePath = sln_parse.find_solution_file() or csproj_parse.find_project_file()
   if solutionFilePath == nil then
     vim.notify(error_messages.no_project_definition_found)
     return


### PR DESCRIPTION
Users can now
- [x] Create F# projects with dotnet new
- [x] Resolve F# projects similiarly to C# projects (build,test,run,etc..)