### PR TITLE
add restore, build for testrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
         viewmode = "split",
         noBuild = true,
         noRestore = true,
+        --- Optional table of extra args e.g "--blame crash"
+        additional_args = {}
       },
       ---@param action "test" | "restore" | "build" | "run"
       terminal = function(path, action)

--- a/lua/easy-dotnet/async-utils.lua
+++ b/lua/easy-dotnet/async-utils.lua
@@ -1,0 +1,50 @@
+local M = {}
+---@alias JobCallback fun(stdout: string[], stderr: string[], exit_code: number)
+
+--- Runs a command asynchronously using `vim.fn.jobstart`.
+--- @param cmd string[] Command and its arguments.
+--- @param callback JobCallback The callback function invoked with stdout, stderr, and exit code.
+M.job_run_async = function(cmd, callback)
+  local stdout_data = {}
+  local stderr_data = {}
+
+  local function on_exit(_, exit_code)
+    callback(stdout_data, stderr_data, exit_code)
+  end
+
+  local function on_stdout(_, data)
+    stdout_data = data
+  end
+
+  local function on_stderr(_, data)
+    stderr_data = data
+  end
+
+  vim.fn.jobstart(cmd, {
+    on_stdout = on_stdout,
+    on_stderr = on_stderr,
+    on_exit = on_exit,
+    stdout_buffered = true,
+    stderr_buffered = true,
+  })
+end
+
+-- await: Function to suspend a coroutine until an async function completes
+-- Must be wrapped in a coroutine
+--- Wraps an async function, suspending the coroutine until the job completes.
+--- @param async_function fun(cmd: string[], callback: JobCallback)
+--- @return fun(...: any): string[], string[], number
+M.await = function(async_function)
+  return function(...)
+    local co = coroutine.running()
+    assert(co, "await function must be called within a coroutine")
+
+    async_function(..., function(stdout, stderr, exit_code)
+      coroutine.resume(co, stdout, stderr, exit_code)
+    end)
+
+    return coroutine.yield()
+  end
+end
+
+return M

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -2,6 +2,7 @@
 ---@field noBuild boolean
 ---@field noRestore boolean
 ---@field viewmode "float" | "buf" | "split"
+---@field additional_args table<string> | nil
 
 local function get_sdk_path()
   local sdk_version = vim.system({ "dotnet", "--version" }):wait().stdout:gsub("\r", ""):gsub("\n", "")
@@ -60,6 +61,7 @@ return {
     viewmode = "split",
     noBuild = true,
     noRestore = true,
+    additional_args = {}
   },
   csproj_mappings = true,
   auto_bootstrap_namespace = true

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -1,6 +1,7 @@
 ---@class TestRunnerOptions
 ---@field noBuild boolean
 ---@field noRestore boolean
+---@field viewmode "float" | "buf" | "split"
 
 local function get_sdk_path()
   local sdk_version = vim.system({ "dotnet", "--version" }):wait().stdout:gsub("\r", ""):gsub("\n", "")
@@ -53,7 +54,6 @@ return {
   },
   ---@type TestRunnerOptions
   test_runner = {
-    ---@type "split" | "float" | "buf"
     viewmode = "split",
     noBuild = true,
     noRestore = true,

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -84,7 +84,7 @@ local function get_dotnet_args(options)
   if options.noRestore == true then
     table.insert(args, "--no-restore")
   end
-  return table.concat(args, " ")
+  return table.concat(args, " ") .. " " .. table.concat(options.additional_args or {}, " ")
 end
 
 local function run_csproject(win, cs_project_path)

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -143,7 +143,7 @@ local function run_test_group(line, win)
 
   local on_job_finished = win.appendJob(line.name, "Run", testcount)
   vim.fn.jobstart(
-    string.format("dotnet test --filter='%s' %s --no-restore %s --logger='trx;logFileName=%s'",
+    string.format("dotnet test --filter='%s' --nologo %s %s --logger='trx;logFileName=%s'",
       suite_name, get_dotnet_args(win.options), line.cs_project_path, log_file_name),
     {
       on_exit = function()


### PR DESCRIPTION
## Description
Will add the option to pass `--no-build` and `--no-restore` using the properties `noBuild` and `noRestore` in the test_runner options section

## Features
- [x] no-restore, no-build when opening testrunner
- [x] no-restore, no-build when running tests in testrunner
- [x] Allow passing additional args using options

## Consider
- [ ] When building upon opening the testrunner, consider using quickfix build