### PR TITLE
feat: use msbuild for project version

### DIFF
--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -66,7 +66,7 @@ M.get_dll_for_solution_project = function(sln_file)
 
   local path = vim.fs.dirname(project.path)
   return {
-    dll = project.dll_path,
+    dll = project.get_dll_path(),
     project = path,
     projectName = project.name
   }
@@ -81,7 +81,7 @@ M.get_dll_for_project = function()
   local path = vim.fs.dirname(project.path)
   return {
     projectName = project.name,
-    dll = project.dll_path,
+    dll = project.get_dll_path(),
     project = path
   }
 end

--- a/lua/easy-dotnet/default-manager.lua
+++ b/lua/easy-dotnet/default-manager.lua
@@ -1,7 +1,3 @@
----@class DotnetProject
----@field name string
----@field path string
-
 ---@class SolutionContent
 ---@field default_build_project string
 ---@field default_test_project string

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -73,14 +73,13 @@ end
 
 
 ---@type table<string, DotnetProject>
-local cache = {}
-
+local project_cache = {}
 
 -- Get the project definition from a csproj/fsproj file
 ---@param project_file_path string
 ---@return DotnetProject
 M.get_project_from_project_file = function(project_file_path)
-  local maybeCacheObject = cache[project_file_path]
+  local maybeCacheObject = project_cache[project_file_path]
   if maybeCacheObject then
     return maybeCacheObject
   end
@@ -128,7 +127,7 @@ M.get_project_from_project_file = function(project_file_path)
     runnable = isWebProject or isConsoleProject,
     secrets = maybeSecretGuid,
     get_dll_path = function()
-      local c = cache[project_file_path]
+      local c = project_cache[project_file_path]
       if c and c.dll_path then
         return c.dll_path
       end
@@ -150,9 +149,9 @@ M.get_project_from_project_file = function(project_file_path)
     isWebProject = isWebProject
   }
 
-  cache[project_file_path] = project
+  project_cache[project_file_path] = project
   if version then
-    cache[project_file_path].dll_path = vim.fs.joinpath(vim.fs.dirname(project_file_path), "bin", "Debug",
+    project_cache[project_file_path].dll_path = vim.fs.joinpath(vim.fs.dirname(project_file_path), "bin", "Debug",
       "net" .. version, name .. ".dll")
   end
 

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -118,6 +118,11 @@ M.get_project_from_project_file = function(project_file_path)
     runnable = isWebProject or isConsoleProject,
     secrets = maybeSecretGuid,
     get_dll_path = function()
+      if version and version ~= false then
+        local bin_path = vim.fs.joinpath(vim.fs.dirname(project_file_path), "bin", "Debug", "net" .. version)
+        local dll_path = vim.fs.joinpath(bin_path, name .. ".dll")
+        return dll_path
+      end
       local value = vim.fn.json_decode(
             vim.fn.system(string.format(
               "dotnet msbuild %s -getProperty:OutputPath -getProperty:TargetExt -getProperty:AssemblyName",

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -72,7 +72,7 @@ local function extractProjectName(path)
   return filename:gsub("%.csproj$", ""):gsub("%.fsproj$", "")
 end
 
-local function find_dotnet_sdk_version_in_build_file(starting_directory)
+local function get_version_from_build_props(starting_directory)
   local current_directory = starting_directory
 
   while current_directory do
@@ -141,12 +141,12 @@ M.get_project_from_project_file = function(project_file_path)
   local isTestProject = M.is_test_project(project_file_path)
   local maybeSecretGuid = M.try_get_secret_id(project_file_path)
   local version = M.extract_version(project_file_path) or get_version_from_props(project_file_path) or
-      find_dotnet_sdk_version_in_build_file(vim.fs.dirname(project_file_path))
+      get_version_from_build_props(vim.fs.dirname(project_file_path))
 
   local bin_path = vim.fs.joinpath(vim.fs.dirname(project_file_path), "bin", "Debug", "net" .. version)
   local dll_path = vim.fs.joinpath(bin_path, name .. ".dll")
 
-  if version then
+  if version and version ~= false then
     display = display .. "@" .. version
   end
 

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@field display string
 ---@field path string
 ---@field name string
----@field version string
+---@field version string|nil
 ---@field runnable boolean
 ---@field secrets string
 ---@field get_dll_path function

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -91,7 +91,6 @@ M.get_project_from_project_file = function(project_file_path)
   local isConsoleProject = M.is_console_project(project_file_path)
   local isTestProject = M.is_test_project(project_file_path)
   local maybeSecretGuid = M.try_get_secret_id(project_file_path)
-
   local version = M.extract_version(project_file_path)
 
   if version then

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -316,6 +316,7 @@ M.runner = function(options, sdk_path)
         highlight = "Character"
       }
       local on_job_finished = win.appendJob(value.name, "Discovery")
+      --Performance reasons
       if not value.version then
         vim.schedule(function()
           discover_tests_for_project_and_update_lines(project, win, mergedOpts, value, sdk_path, on_job_finished)

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -155,10 +155,12 @@ local default_options = require("easy-dotnet.options").test_runner
 ---@param project Test
 ---@param options TestRunnerOptions
 ---@param sdk_path string
-local function discover_tests_for_project_and_update_lines(project, win, options, dll_path, sdk_path)
-  local on_job_finished = win.appendJob(project, "Discovery")
+---@param dotnet_project DotnetProject
+---@param on_job_finished function
+local function discover_tests_for_project_and_update_lines(project, win, options, dotnet_project, sdk_path,
+                                                           on_job_finished)
   local vstest_dll = vim.fs.joinpath(sdk_path, "vstest.console.dll")
-  local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dll_path)
+  local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dotnet_project.get_dll_path())
   local outfile = os.tmpname()
   local script_path = require("easy-dotnet.test-runner.discovery").get_script_path()
   local command = string.format("dotnet fsi %s '%s' '%s' '%s'", script_path, vstest_dll,
@@ -313,7 +315,10 @@ M.runner = function(options, sdk_path)
         expand = {},
         highlight = "Character"
       }
-      discover_tests_for_project_and_update_lines(project, win, mergedOpts, value.dll_path, sdk_path)
+      local on_job_finished = win.appendJob(value.name, "Discovery")
+      vim.schedule(function()
+        discover_tests_for_project_and_update_lines(project, win, mergedOpts, value, sdk_path, on_job_finished)
+      end)
     end
   end
 

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -316,9 +316,13 @@ M.runner = function(options, sdk_path)
         highlight = "Character"
       }
       local on_job_finished = win.appendJob(value.name, "Discovery")
-      vim.schedule(function()
+      if not value.version then
+        vim.schedule(function()
+          discover_tests_for_project_and_update_lines(project, win, mergedOpts, value, sdk_path, on_job_finished)
+        end)
+      else
         discover_tests_for_project_and_update_lines(project, win, mergedOpts, value, sdk_path, on_job_finished)
-      end)
+      end
     end
   end
 


### PR DESCRIPTION
Changed the logic regarding dotnet version for a specific project, this property can be set using MSBuild configurations.

Version in the `DotnetProject` class is now `string|nil`. 
The `dll_path` field is removed in favor of the `get_dll_path` this is due to having to call dotnet msbuild command to get the output path.
This is safer because the previous dll_path was a best guess whilst this is more of a guaranteed path