### PR TITLE
feat: add experimental support for debugging unit tests

### DIFF
--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -43,7 +43,6 @@ local function run_job_sync(cmd)
 end
 
 local function start_test_process(path)
-  -- local test_file_dir = vim.fs.dirname(vim.fn.expand("%"))
   local command = string.format("dotnet test %s --environment=VSTEST_HOST_DEBUG=1", path)
   local res = run_job_sync(command)
   if not res.process_id then

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -19,6 +19,54 @@ M.get_debug_dll = function()
   }
 end
 
+local function run_job_sync(cmd)
+  local result = {}
+  local co = coroutine.running()
+
+  vim.fn.jobstart(cmd, {
+    stdout_buffered = false,
+    on_stdout = function(_, data, _)
+      for _, line in ipairs(data) do
+        local match = string.match(line, "Process Id: (%d+)")
+        if match then
+          result.process_id = tonumber(match)
+          coroutine.resume(co)
+          return
+        end
+      end
+    end,
+  })
+
+  coroutine.yield()
+
+  return result
+end
+
+local function start_test_process(path)
+  -- local test_file_dir = vim.fs.dirname(vim.fn.expand("%"))
+  local command = string.format("dotnet test %s --environment=VSTEST_HOST_DEBUG=1", path)
+  local res = run_job_sync(command)
+  if not res.process_id then
+    error("Failed to start process")
+  end
+  return res.process_id
+end
+
+
+M.get_tbn = function()
+  local sln_file = sln_parse.find_solution_file()
+  assert(sln_file, "Failed to find a solution filej")
+  local projects = sln_parse.get_projects_from_sln(sln_file)
+  local test_project = picker.pick_sync(nil, projects, "Pick test project")
+  assert(test_project, "No project selected")
+
+  local process_id = start_test_process(vim.fs.dirname(test_project.path))
+  return {
+    process_id = process_id,
+    cwd = test_project.path
+  }
+end
+
 M.get_environment_variables = function(project_name, relative_project_path)
   local launchSettings = vim.fs.joinpath(relative_project_path, "Properties", "launchSettings.json")
 

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -53,11 +53,14 @@ local function start_test_process(path)
 end
 
 
-M.get_tbn = function()
+M.start_debugging_test_project = function()
   local sln_file = sln_parse.find_solution_file()
   assert(sln_file, "Failed to find a solution filej")
   local projects = sln_parse.get_projects_from_sln(sln_file)
-  local test_project = picker.pick_sync(nil, projects, "Pick test project")
+  local test_projects = extensions.filter(projects, function(i)
+    return i.isTestProject
+  end)
+  local test_project = picker.pick_sync(nil, test_projects, "Pick test project")
   assert(test_project, "No project selected")
 
   local process_id = start_test_process(vim.fs.dirname(test_project.path))

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -121,6 +121,7 @@ M.setup = function(opts)
 end
 
 M.get_debug_dll = debug.get_debug_dll
+M.get_tbn = debug.get_tbn
 M.get_environment_variables = debug.get_environment_variables
 
 M.is_dotnet_project = function()

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -121,8 +121,11 @@ M.setup = function(opts)
 end
 
 M.get_debug_dll = debug.get_debug_dll
-M.start_debugging_test_project = debug.start_debugging_test_project
 M.get_environment_variables = debug.get_environment_variables
+
+M.experimental = {
+  start_debugging_test_project = debug.start_debugging_test_project
+}
 
 M.is_dotnet_project = function()
   local project_files = require("easy-dotnet.parsers.sln-parse").find_solution_file() or

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -121,7 +121,7 @@ M.setup = function(opts)
 end
 
 M.get_debug_dll = debug.get_debug_dll
-M.get_tbn = debug.get_tbn
+M.start_debugging_test_project = debug.start_debugging_test_project
 M.get_environment_variables = debug.get_environment_variables
 
 M.is_dotnet_project = function()


### PR DESCRIPTION
Adds experimental support for debugging unit tests. This functionality relies on `dotnet test --environment=VSTEST_HOST_DEBUG=1`. Tested on basic test projects and seems to work great so far. Not sure about environment variables yet.