### PR TITLE
feat: add support for extra args in Dotnet build|test|run

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ dotnet.is_dotnet_project()                          -- Returns true if a csproje
 
 ### Vim commands
 ```
-Dotnet run
-Dotnet test
+Dotnet run (release|debug)
+Dotnet test (release|debug)
 Dotnet restore
-Dotnet build
+Dotnet build (release|debug)
 Dotnet clean
 Dotnet secrets
 Dotnet testrunner

--- a/lua/easy-dotnet/actions/build.lua
+++ b/lua/easy-dotnet/actions/build.lua
@@ -50,7 +50,7 @@ end
 
 ---@param term function
 ---@param use_default boolean
-M.build_project_picker = function(term, use_default)
+M.build_project_picker = function(term, use_default, args)
   local solutionFilePath = sln_parse.find_solution_file()
   if solutionFilePath == nil then
     csproj_fallback(term)
@@ -58,7 +58,7 @@ M.build_project_picker = function(term, use_default)
   end
 
   select_project(solutionFilePath, function(project)
-    term(project.path, "build")
+    term(project.path, "build", args)
   end, use_default)
 end
 

--- a/lua/easy-dotnet/actions/run.lua
+++ b/lua/easy-dotnet/actions/run.lua
@@ -19,7 +19,8 @@ end
 
 ---@param term function
 ---@param use_default boolean
-M.run_project_picker = function(term, use_default)
+---@param args string
+M.run_project_picker = function(term, use_default, args)
   local default_manager = require("easy-dotnet.default-manager")
   local solution_file_path = sln_parse.find_solution_file()
   if solution_file_path == nil then
@@ -29,7 +30,7 @@ M.run_project_picker = function(term, use_default)
 
   local default = default_manager.check_default_project(solution_file_path, "run")
   if default ~= nil and use_default == true then
-    term(default.path, "run")
+    term(default.path, "run", args)
     return
   end
 
@@ -42,7 +43,7 @@ M.run_project_picker = function(term, use_default)
     return
   end
   picker.picker(nil, projects, function(i)
-    term(i.path, "run")
+    term(i.path, "run", args)
     default_manager.set_default_project(i, solution_file_path, "run")
   end, "Run project")
 end

--- a/lua/easy-dotnet/actions/test.lua
+++ b/lua/easy-dotnet/actions/test.lua
@@ -49,7 +49,8 @@ end
 
 
 ---@param use_default boolean
-M.run_test_picker = function(on_select, use_default)
+---@param args string
+M.run_test_picker = function(on_select, use_default, args)
   local solutionFilePath = sln_parse.find_solution_file()
   if solutionFilePath == nil then
     csproj_fallback(on_select)
@@ -57,7 +58,7 @@ M.run_test_picker = function(on_select, use_default)
   end
 
   select_project(solutionFilePath, function(project)
-    on_select(project.path, "test")
+    on_select(project.path, "test", args)
   end, use_default)
 end
 

--- a/lua/easy-dotnet/actions/test.lua
+++ b/lua/easy-dotnet/actions/test.lua
@@ -1,10 +1,10 @@
 local M = {}
 local extensions = require("easy-dotnet.extensions")
 local picker = require("easy-dotnet.picker")
+local error_messages = require("easy-dotnet.error-messages")
 local parsers = require("easy-dotnet.parsers")
 local csproj_parse = parsers.csproj_parser
 local sln_parse = parsers.sln_parser
-local error_messages = require("easy-dotnet.error-messages")
 
 local function csproj_fallback(on_select)
   local csproj_path = csproj_parse.find_project_file()
@@ -49,7 +49,7 @@ end
 
 
 ---@param use_default boolean
----@param args string
+---@param args string|nil
 M.run_test_picker = function(on_select, use_default, args)
   local solutionFilePath = sln_parse.find_solution_file()
   if solutionFilePath == nil then
@@ -143,7 +143,5 @@ M.test_watcher = function()
     })
   end
 end
-
-
 
 return M

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -16,6 +16,21 @@ local function merge_tables(table1, table2)
   return merged
 end
 
+---@param argument string|nil
+local function args_handler(argument)
+  if not argument then
+    return nil
+  end
+  local loweredArgument = argument:lower()
+  if loweredArgument == "release" then
+    return "-c release"
+  elseif loweredArgument == "debug" then
+    return "-c debug"
+  else
+    vim.notify("Unknown argument to dotnet build " .. argument, vim.log.levels.WARN)
+  end
+end
+
 M.setup = function(opts)
   local merged_opts = merge_tables(options, opts or {})
   vim.api.nvim_set_hl(0, "EasyDotnetPackage", {
@@ -32,14 +47,14 @@ M.setup = function(opts)
     run = function()
       actions.run(merged_opts.terminal, false)
     end,
-    test = function()
-      actions.test(merged_opts.terminal, false)
+    test = function(args)
+      actions.test(merged_opts.terminal, false, args_handler(args[2]))
     end,
     restore = function()
       actions.restore(merged_opts.terminal)
     end,
-    build = function()
-      actions.build(merged_opts.terminal, false)
+    build = function(args)
+      actions.build(merged_opts.terminal, false, args_handler(args[2]))
     end,
     testrunner = function()
       require("easy-dotnet.test-runner.runner").runner(merged_opts.test_runner, merged_opts.get_sdk_path())
@@ -55,18 +70,29 @@ M.setup = function(opts)
     end
   }
 
+  ---@return table<string>
+  local function split_by_whitespace(str)
+    local words = {}
+    for word in str:gmatch("%S+") do
+      table.insert(words, word)
+    end
+    return words
+  end
+
   vim.api.nvim_create_user_command('Dotnet',
     function(commandOpts)
-      local subcommand = commandOpts.fargs[1]
+      local args = split_by_whitespace(commandOpts.fargs[1])
+      print(vim.inspect(args))
+      local subcommand = args[1]
       local func = commands[subcommand]
       if func then
-        func()
+        func(args)
       else
         print("Invalid subcommand:", subcommand)
       end
     end,
     {
-      nargs = 1,
+      nargs = "?",
       complete = function()
         local completion = {}
         for key, _ in pairs(commands) do
@@ -103,6 +129,7 @@ M.setup = function(opts)
   M.build_default_quickfix = function(dotnet_args)
     actions.build_quickfix(true, dotnet_args)
   end
+
   M.build_quickfix = function(dotnet_args)
     actions.build_quickfix(false, dotnet_args)
   end

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -44,17 +44,17 @@ M.setup = function(opts)
     secrets = function()
       secrets.edit_secrets_picker(merged_opts.secrets.path)
     end,
-    run = function()
-      actions.run(merged_opts.terminal, false)
+    run = function(args)
+      actions.run(merged_opts.terminal, false, args_handler(args[2]) or "")
     end,
     test = function(args)
-      actions.test(merged_opts.terminal, false, args_handler(args[2]))
+      actions.test(merged_opts.terminal, false, args_handler(args[2]) or "")
     end,
     restore = function()
       actions.restore(merged_opts.terminal)
     end,
     build = function(args)
-      actions.build(merged_opts.terminal, false, args_handler(args[2]))
+      actions.build(merged_opts.terminal, false, args_handler(args[2]) or "")
     end,
     testrunner = function()
       require("easy-dotnet.test-runner.runner").runner(merged_opts.test_runner, merged_opts.get_sdk_path())

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -31,19 +31,20 @@ return {
   get_sdk_path = get_sdk_path,
   ---@param path string
   ---@param action "test"|"restore"|"build"|"run"
-  terminal = function(path, action)
+  ---@param args string | nil
+  terminal = function(path, action, args)
     local commands = {
       run = function()
-        return "dotnet run --project " .. path
+        return string.format("dotnet run --project %s %s", path, args)
       end,
       test = function()
-        return "dotnet test " .. path
+        return string.format("dotnet test %s %s", path, args)
       end,
       restore = function()
-        return "dotnet restore " .. path
+        return string.format("dotnet restore %s %s", path, args)
       end,
       build = function()
-        return "dotnet build " .. path
+        return string.format("dotnet build %s %s", path, args)
       end
     }
     local command = commands[action]()

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -31,7 +31,7 @@ return {
   get_sdk_path = get_sdk_path,
   ---@param path string
   ---@param action "test"|"restore"|"build"|"run"
-  ---@param args string | nil
+  ---@param args string
   terminal = function(path, action, args)
     local commands = {
       run = function()


### PR DESCRIPTION
Will allow users to call `Dotnet build release` which in turn will result in `dotnet build -c release`. I intentionally do not blindly allow args and will add sensible commands. If calling `Dotnet build -c release` then whats the point of abstractions? I might expose a raw arg at some point. We'll see


This PR requires changes for those who have set the terminal option in their call to the setup function. Otherwise args will not be propagated.


- [x] expose -c flag to test `Dotnet test release`
- [x] expose -c flag to build `Dotnet build release`
- [x] expose -c flag to run `Dotnet build release`
- [x] update readme