### PR TITLE
feat(ef): add ef core integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 10. [New](#new)
     - [Project](#project)
     - [Configuration file](#configuration-file)
-11. [Nvim-dap configuration](#nvim-dap-configuration)
+11. [EntityFramework](#ef)
+    - [Database](#database)
+    - [Migrations](#migrations)
+12. [Nvim-dap configuration](#nvim-dap-configuration)
     - [Basic example](#basic-example)
     - [Advanced example](#advanced-example)
-12. [Advanced configurations](#advanced-configurations)
+13. [Advanced configurations](#advanced-configurations)
     - [Overseer](#overseer)
 
 ## Features
@@ -236,6 +239,21 @@ https://github.com/user-attachments/assets/aa067c17-3611-4490-afc8-41d98a526729
 If a configuration file is selected it will
 1. Create the configuration file and place it next to your solution file. (solution files and gitignore files are placed in cwd)
 
+## EntityFramework
+Common EntityFramework commands have been added mainly to reduce the overhead of writing `--project .. --startup-project ..`. 
+
+### Requirements
+This functionality relies on dotnet-ef tool, install using `dotnet tool install --global dotnet-ef`
+
+### Database
+- `Dotnet ef database update`
+- `Dotnet ef database update pick` --allows to pick which migration to apply
+- `Dotnet ef database drop`
+
+### Migrations
+- `Dotnet ef migrations add <name>`
+- `Dotnet ef migrations remove`
+- `Dotnet ef migrations list`
 
 ## Nvim-dap configuration
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 10. [New](#new)
     - [Project](#project)
     - [Configuration file](#configuration-file)
-11. [EntityFramework](#ef)
+11. [EntityFramework](#entityframework)
     - [Database](#database)
     - [Migrations](#migrations)
 12. [Nvim-dap configuration](#nvim-dap-configuration)

--- a/lua/easy-dotnet/ef-core/database.lua
+++ b/lua/easy-dotnet/ef-core/database.lua
@@ -1,11 +1,42 @@
 local M = {}
 
-M.database_update = function()
+M.database_update = function(migration_name)
+  local selected_migration = { value = "" }
   local selections = require("easy-dotnet.ef-core.utils").pick_projects()
   local project = selections.project
   local startup_project = selections.startup_project
 
-  local cmd = string.format("dotnet ef database update --project %s --startup-project %s", project.path,
+
+  if migration_name == "pick" then
+    local cmd = string.format("dotnet ef migrations list --prefix-output --project %s --startup-project %s", project
+      .path, startup_project.path)
+    local stdout = vim.fn.system(cmd)
+    local migrations = {}
+    local lines = {}
+    for line in stdout:gmatch("[^\r\n]+") do
+      table.insert(lines, line)
+    end
+    for _, value in ipairs(lines) do
+      local migration = value:match("^data:%s*(%S+)")
+      if migration then
+        table.insert(migrations, {
+          display = migration,
+          value = migration,
+          ordinal = migration
+        })
+      end
+    end
+
+    local selected = require("easy-dotnet.picker").pick_sync(nil, migrations)
+    assert(selected, "No migration selected")
+    selected_migration = selected
+  end
+
+
+  print(vim.inspect(selected_migration))
+  local cmd = string.format("dotnet ef database update %s --project %s --startup-project %s",
+    selected_migration.value,
+    project.path,
     startup_project.path)
   vim.notify(cmd)
   vim.fn.jobstart(cmd, {

--- a/lua/easy-dotnet/ef-core/database.lua
+++ b/lua/easy-dotnet/ef-core/database.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+M.database_update = function()
+  local selections = require("easy-dotnet.ef-core.utils").pick_projects()
+  local project = selections.project
+  local startup_project = selections.startup_project
+
+  local cmd = string.format("dotnet ef database update --project %s --startup-project %s", project.path,
+    startup_project.path)
+  vim.notify(cmd)
+  vim.fn.jobstart(cmd, {
+    on_stdout = function(_, data)
+
+    end,
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Success")
+      else
+        vim.notify("Failed", vim.log.levels.ERROR)
+      end
+    end
+  })
+end
+--
+M.database_drop = function()
+  local selections = require("easy-dotnet.ef-core.utils").pick_projects()
+  local project = selections.project
+  local startup_project = selections.startup_project
+
+  local cmd = string.format("dotnet ef database drop --project %s --startup-project %s -f", project.path,
+    startup_project.path)
+  vim.notify(cmd)
+  vim.fn.jobstart(cmd, {
+    on_stdout = function(_, data)
+
+    end,
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Success")
+      else
+        vim.notify("Failed", vim.log.levels.ERROR)
+      end
+    end
+  })
+end
+
+return M

--- a/lua/easy-dotnet/ef-core/database.lua
+++ b/lua/easy-dotnet/ef-core/database.lua
@@ -1,12 +1,12 @@
 local M = {}
 
-M.database_update = function(migration_name)
+M.database_update = function(mode)
   local selected_migration = { value = "" }
   local selections = require("easy-dotnet.ef-core.utils").pick_projects()
   local project = selections.project
   local startup_project = selections.startup_project
 
-  if migration_name == "pick" then
+  if mode == "pick" then
     local cmd = string.format("dotnet ef migrations list --prefix-output --project %s --startup-project %s", project
       .path, startup_project.path)
     local stdout = vim.fn.system(cmd)

--- a/lua/easy-dotnet/ef-core/database.lua
+++ b/lua/easy-dotnet/ef-core/database.lua
@@ -6,7 +6,6 @@ M.database_update = function(migration_name)
   local project = selections.project
   local startup_project = selections.startup_project
 
-
   if migration_name == "pick" then
     local cmd = string.format("dotnet ef migrations list --prefix-output --project %s --startup-project %s", project
       .path, startup_project.path)
@@ -33,21 +32,22 @@ M.database_update = function(migration_name)
   end
 
 
-  print(vim.inspect(selected_migration))
+  local spinner = require("easy-dotnet.ui-modules.spinner").new()
   local cmd = string.format("dotnet ef database update %s --project %s --startup-project %s",
     selected_migration.value,
     project.path,
     startup_project.path)
-  vim.notify(cmd)
+
+  spinner:start_spinner("Applying migrations")
   vim.fn.jobstart(cmd, {
     on_stdout = function(_, data)
 
     end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
+        spinner:stop_spinner("Database updated")
       else
-        vim.notify("Failed", vim.log.levels.ERROR)
+        spinner:stop_spinner("Database update failed", vim.log.levels.ERROR)
       end
     end
   })
@@ -58,18 +58,16 @@ M.database_drop = function()
   local project = selections.project
   local startup_project = selections.startup_project
 
+  local spinner = require("easy-dotnet.ui-modules.spinner").new()
   local cmd = string.format("dotnet ef database drop --project %s --startup-project %s -f", project.path,
     startup_project.path)
-  vim.notify(cmd)
+  spinner:start_spinner("Dropping database")
   vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data)
-
-    end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
+        spinner:stop_spinner("Database dropped")
       else
-        vim.notify("Failed", vim.log.levels.ERROR)
+        spinner:stop_spinner("Failed to drop database", vim.log.levels.ERROR)
       end
     end
   })

--- a/lua/easy-dotnet/ef-core/dbcontext.lua
+++ b/lua/easy-dotnet/ef-core/dbcontext.lua
@@ -1,3 +1,0 @@
-local M = {}
-
-return M

--- a/lua/easy-dotnet/ef-core/dbcontext.lua
+++ b/lua/easy-dotnet/ef-core/dbcontext.lua
@@ -1,0 +1,3 @@
+local M = {}
+
+return M

--- a/lua/easy-dotnet/ef-core/migration.lua
+++ b/lua/easy-dotnet/ef-core/migration.lua
@@ -2,7 +2,10 @@ local M = {}
 
 ---@param migration_name string
 M.add_migration = function(migration_name)
-  assert(migration_name, "Migration name required")
+  if not migration_name then
+    vim.notify("Migration name required", vim.log.levels.ERROR)
+    return
+  end
   local selections = require("easy-dotnet.ef-core.utils").pick_projects()
   local project = selections.project
   local startup_project = selections.startup_project

--- a/lua/easy-dotnet/ef-core/migration.lua
+++ b/lua/easy-dotnet/ef-core/migration.lua
@@ -1,0 +1,107 @@
+local M = {}
+
+---@param migration_name string
+M.add_migration = function(migration_name)
+  assert(migration_name, "Migration name required")
+  local selections = require("easy-dotnet.ef-core.utils").pick_projects()
+  local project = selections.project
+  local startup_project = selections.startup_project
+
+  local cmd = string.format("dotnet ef migrations add %s --project %s --startup-project %s", migration_name, project
+    .path,
+    startup_project.path)
+  vim.notify(cmd)
+  vim.fn.jobstart(cmd, {
+    on_stdout = function(_, data)
+
+    end,
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Success")
+      else
+        vim.notify("Failed", vim.log.levels.ERROR)
+      end
+    end
+  })
+end
+
+M.remove_migration = function()
+  local selections = require("easy-dotnet.ef-core.utils").pick_projects()
+  local project = selections.project
+  local startup_project = selections.startup_project
+
+  local cmd = string.format("dotnet ef migrations remove %s --project %s --startup-project %s", project.path,
+    startup_project.path)
+  vim.notify(cmd)
+  vim.fn.jobstart(cmd, {
+    on_stdout = function(_, data)
+
+    end,
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Success")
+      else
+        vim.notify("Failed", vim.log.levels.ERROR)
+      end
+    end
+  })
+end
+
+
+M.list_migrations = function()
+  local conf = require('telescope.config').values
+  local selections = require("easy-dotnet.ef-core.utils").pick_projects()
+  local project = selections.project
+  local startup_project = selections.startup_project
+
+  local cmd = string.format("dotnet ef migrations list --prefix-output --project %s --startup-project %s", project.path,
+    startup_project.path)
+  vim.notify(cmd)
+
+  local migrations = {}
+
+  vim.fn.jobstart(cmd, {
+    stdout_buffered = true,
+    ---@param data table<string>
+    on_stdout = function(_, data)
+      -- Iterate over the output lines
+      for _, value in ipairs(data) do
+        -- Strip the "data: " prefix and capture the migration name
+        local migration = value:match("^data:%s*(%S+)")
+        if migration then
+          -- Insert the stripped migration name into the migrations table
+          table.insert(migrations, migration)
+        end
+      end
+    end,
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Success")
+        local opts = {
+          entry_maker = function(entry)
+            return {
+              display = entry,
+              ordinal = entry,
+              path = string.format("%s/Migrations/%s.cs", vim.fs.dirname(selections.project.path), entry),
+              value = entry
+            }
+          end
+        }
+        local picker = require('telescope.pickers').new(opts, {
+          prompt_title = "Migrations",
+          finder = require('telescope.finders').new_table {
+            results = migrations,
+            entry_maker = opts.entry_maker,
+          },
+          sorter = require('telescope.config').values.generic_sorter({}),
+          previewer = conf.grep_previewer(opts)
+        })
+        picker:find()
+      else
+        vim.notify("Failed", vim.log.levels.ERROR)
+      end
+    end
+  })
+end
+
+return M

--- a/lua/easy-dotnet/ef-core/migration.lua
+++ b/lua/easy-dotnet/ef-core/migration.lua
@@ -10,16 +10,14 @@ M.add_migration = function(migration_name)
   local cmd = string.format("dotnet ef migrations add %s --project %s --startup-project %s", migration_name, project
     .path,
     startup_project.path)
-  vim.notify(cmd)
+  local spinner = require("easy-dotnet.ui-modules.spinner").new()
+  spinner:start_spinner("Adding migration")
   vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data)
-
-    end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
+        spinner:stop_spinner("Migration added")
       else
-        vim.notify("Failed", vim.log.levels.ERROR)
+        spinner:stop_spinner("Failed to add migration", vim.log.levels.ERROR)
       end
     end
   })
@@ -30,18 +28,16 @@ M.remove_migration = function()
   local project = selections.project
   local startup_project = selections.startup_project
 
-  local cmd = string.format("dotnet ef migrations remove %s --project %s --startup-project %s", project.path,
+  local spinner = require("easy-dotnet.ui-modules.spinner").new()
+  local cmd = string.format("dotnet ef migrations remove --project %s --startup-project %s", project.path,
     startup_project.path)
-  vim.notify(cmd)
+  spinner:start_spinner("Removing migration")
   vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data)
-
-    end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
+        spinner:stop_spinner("Migration removed")
       else
-        vim.notify("Failed", vim.log.levels.ERROR)
+        spinner:stop_spinner("Failed to remove migration", vim.log.levels.ERROR)
       end
     end
   })
@@ -59,7 +55,8 @@ M.list_migrations = function()
   vim.notify(cmd)
 
   local migrations = {}
-
+  local spinner = require("easy-dotnet.ui-modules.spinner").new()
+  spinner:start_spinner("Loading migrations")
   vim.fn.jobstart(cmd, {
     stdout_buffered = true,
     ---@param data table<string>
@@ -76,7 +73,7 @@ M.list_migrations = function()
     end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
+        spinner:stop_spinner("")
         local opts = {
           entry_maker = function(entry)
             return {
@@ -98,7 +95,7 @@ M.list_migrations = function()
         })
         picker:find()
       else
-        vim.notify("Failed", vim.log.levels.ERROR)
+        spinner:stop_spinner("Failed to load migrations", vim.log.levels.ERROR)
       end
     end
   })

--- a/lua/easy-dotnet/ef-core/utils.lua
+++ b/lua/easy-dotnet/ef-core/utils.lua
@@ -1,0 +1,29 @@
+local picker = require("easy-dotnet.picker")
+local sln_parse = require("easy-dotnet.parsers.sln-parse")
+
+local M = {}
+
+M.pick_projects = function()
+  local sln = require("easy-dotnet.parsers.sln-parse").find_solution_file()
+  assert(sln, "No solution file found")
+  local projects = sln_parse.get_projects_from_sln(sln)
+
+  local project = picker.pick_sync(nil, projects, "Pick project")
+  local sorted = {
+    project
+  }
+  for _, value in ipairs(projects) do
+    if value ~= project then
+      table.insert(sorted, value)
+    end
+  end
+  local startup_project = picker.pick_sync(nil, sorted, "Pick startup project")
+  assert(project, "No project selected")
+  assert(startup_project, "No startup project selected")
+  return {
+    project = project,
+    startup_project = startup_project
+  }
+end
+
+return M

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -69,27 +69,29 @@ M.setup = function(opts)
       require("easy-dotnet.actions.new").new()
     end,
     ef = function(args)
-      print(args)
-      local sub = args[2]
-      if sub == "database" then
-        local co = coroutine.create(M.entity_framework.database.database_update)
-        coroutine.resume(co)
-      elseif sub == "migration" then
-        if args[3] == "add" then
-          local co = coroutine.create(function()
+      local ef_handler = function()
+        local sub = args[2]
+        if sub == "database" then
+          if args[3] == "update" then
+            M.entity_framework.database.database_update(args[4])
+          elseif args[3] == "drop" then
+            M.entity_framework.database.database_drop()
+          end
+        elseif sub == "migrations" then
+          if args[3] == "add" then
             M.entity_framework.migration.add_migration(args[4])
-          end)
-          coroutine.resume(co)
-        elseif args[3] == "remove" then
-          local co = coroutine.create(M.entity_framework.migration.remove_migration)
-          coroutine.resume(co)
-        elseif args[3] == "list" then
-          local co = coroutine.create(M.entity_framework.migration.list_migrations)
-          coroutine.resume(co)
+          elseif args[3] == "remove" then
+            M.entity_framework.migration.remove_migration()
+          elseif args[3] == "list" then
+            M.entity_framework.migration.list_migrations()
+          end
+        else
+          vim.notify("Unknown command")
         end
-      else
-        vim.notify("Unknown command")
       end
+      local co = coroutine.create(ef_handler)
+
+      coroutine.resume(co)
     end
   }
 
@@ -179,8 +181,7 @@ M.experimental = {
 
 M.entity_framework = {
   database = require("easy-dotnet.ef-core.database"),
-  dbcontext = require("easy-dotnet.ef-core.dbcontext"),
-  migration = require("easy-dotnet.ef-core.migration"),
+  migration = require("easy-dotnet.ef-core.migration")
 }
 
 M.is_dotnet_project = function()

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -67,6 +67,29 @@ M.setup = function(opts)
     end,
     new = function()
       require("easy-dotnet.actions.new").new()
+    end,
+    ef = function(args)
+      print(args)
+      local sub = args[2]
+      if sub == "database" then
+        local co = coroutine.create(M.entity_framework.database.database_update)
+        coroutine.resume(co)
+      elseif sub == "migration" then
+        if args[3] == "add" then
+          local co = coroutine.create(function()
+            M.entity_framework.migration.add_migration(args[4])
+          end)
+          coroutine.resume(co)
+        elseif args[3] == "remove" then
+          local co = coroutine.create(M.entity_framework.migration.remove_migration)
+          coroutine.resume(co)
+        elseif args[3] == "list" then
+          local co = coroutine.create(M.entity_framework.migration.list_migrations)
+          coroutine.resume(co)
+        end
+      else
+        vim.notify("Unknown command")
+      end
     end
   }
 
@@ -152,6 +175,12 @@ M.get_environment_variables = debug.get_environment_variables
 
 M.experimental = {
   start_debugging_test_project = debug.start_debugging_test_project
+}
+
+M.entity_framework = {
+  database = require("easy-dotnet.ef-core.database"),
+  dbcontext = require("easy-dotnet.ef-core.dbcontext"),
+  migration = require("easy-dotnet.ef-core.migration"),
 }
 
 M.is_dotnet_project = function()

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -107,7 +107,6 @@ M.setup = function(opts)
   vim.api.nvim_create_user_command('Dotnet',
     function(commandOpts)
       local args = split_by_whitespace(commandOpts.fargs[1])
-      print(vim.inspect(args))
       local subcommand = args[1]
       local func = commands[subcommand]
       if func then
@@ -147,8 +146,9 @@ M.setup = function(opts)
     actions.test_watcher()
   end
   M.run_project = commands.run
+
   M.run_default = function()
-    actions.run(merged_opts.terminal, true)
+    actions.run(merged_opts.terminal, true, "")
   end
 
   M.build_default_quickfix = function(dotnet_args)


### PR DESCRIPTION
Partly implements: #85 

Trying to make a basic ef core abstraction to utilize the project picker for picking startup-project and project

- [x] `dotnet ef database drop`
- [x] `dotnet ef database update`
- [x] `dotnet ef database update pick` //allows for picking a specific migration to apply
- [x] `dotnet ef migrations add`
- [x] `dotnet ef migrations remove`
- [x] `dotnet ef migrations list`


Will test it out for now and probably add some sort of default manager in the future. Selecting project and startup project is tedious but I think it will be impossible to programatically resolve if startup project is needed.

Does not support multiple db contexts yet.