### PR TITLE
feat(nuget): add nuget support

### DIFF
--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -15,6 +15,7 @@ local function notInList(list, value)
   return true
 end
 
+
 -- Gives a picker for adding a project reference to a csproject
 local function add_project_reference(curr_project_path)
   local this_project = csproj.get_project_from_project_file(curr_project_path)

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -92,6 +92,17 @@ M.setup = function(opts)
       local co = coroutine.create(ef_handler)
 
       coroutine.resume(co)
+    end,
+    package = function(args)
+      local package_handler = function()
+        local sub = args[2]
+        if sub == "add" then
+          require("easy-dotnet.nuget.add").add_package()
+        end
+      end
+      local co = coroutine.create(package_handler)
+
+      coroutine.resume(co)
     end
   }
 
@@ -182,6 +193,10 @@ M.experimental = {
 M.entity_framework = {
   database = require("easy-dotnet.ef-core.database"),
   migration = require("easy-dotnet.ef-core.migration")
+}
+
+M.nuget = {
+  add_package = require("easy-dotnet.nuget.add").add_package
 }
 
 M.is_dotnet_project = function()

--- a/lua/easy-dotnet/nuget/add.lua
+++ b/lua/easy-dotnet/nuget/add.lua
@@ -1,0 +1,25 @@
+local picker = require("easy-dotnet.picker")
+local csproj = require("easy-dotnet.parsers.csproj-parse")
+local sln_parse = require("easy-dotnet.parsers.sln-parse")
+local error_messages = require("easy-dotnet.error-messages")
+
+local M = {}
+
+--dotnet package search EntityFrameworkCore.Sql --format json --take 2
+function M.add_package()
+  local sln = require("easy-dotnet.parsers.sln-parse").find_solution_file()
+  assert(sln, "No solution file found")
+  local projects = sln_parse.get_projects_from_sln(sln)
+
+  local project = picker.pick_sync(nil, projects, "Pick project")
+
+  local input = { "echo", "hello" }
+  local opts = {
+    finder = require("telescope.finders").new_async_job(input)
+
+  }
+  local picker = require("telescope.pickers").new(opts):find()
+  -- dynamic_picker()
+end
+
+return M


### PR DESCRIPTION
 Following command can be used for autocomplete/search: `dotnet package search --format json --take 2 | jq '.searchResult | .[] | .packages | .[] | \"\(.id):\(.latestVersion)\"'`

Should I create the module as an autocomplete and csproj mapping? Giving the low level vibe of neovim. Or should i make some sort of UI using Telescope


## Nuget UI
- Telescope async pickers seem complicated
- Making an intuitive non-laggy ui will be hard
- likely reliance on `jq`
- feature packed

## Csproj mappings
- Works well with outdated command
- Clean and easy to use
- barebones but does the job