### PR TITLE
fix(term): some term commands concatenated nil causing command to fail

### DIFF
--- a/lua/easy-dotnet/actions/build.lua
+++ b/lua/easy-dotnet/actions/build.lua
@@ -44,7 +44,7 @@ local function csproj_fallback(term)
     return
   end
   picker.picker(nil, { { name = csproj_path, display = csproj_path, path = csproj_path } }, function(i)
-    term(i.path, "build")
+    term(i.path, "build", "")
   end, "Build project(s)")
 end
 
@@ -136,7 +136,7 @@ M.build_project_quickfix = function(use_default, dotnet_args)
       return
     end
     local spinner = require("easy-dotnet.ui-modules.spinner").new()
-    spinner:start_spinner("Building", "dots")
+    spinner:start_spinner("Building")
     M.pending = true
     local command = string.format("dotnet build %s /flp:v=q /flp:logfile='%s' %s", project.path, logPath,
       dotnet_args or "")
@@ -161,7 +161,7 @@ M.build_solution = function(term)
     vim.notify(error_messages.no_project_definition_found)
     return
   end
-  term(solutionFilePath, "build")
+  term(solutionFilePath, "build", "")
 end
 
 return M

--- a/lua/easy-dotnet/actions/restore.lua
+++ b/lua/easy-dotnet/actions/restore.lua
@@ -12,7 +12,7 @@ M.restore = function(term)
     return
   end
 
-  term(project, "restore")
+  term(project, "restore", "")
 end
 
 

--- a/lua/easy-dotnet/actions/test.lua
+++ b/lua/easy-dotnet/actions/test.lua
@@ -68,7 +68,7 @@ M.test_solution = function(term)
     vim.notify(error_messages.no_project_definition_found)
     return
   end
-  term(solutionFilePath, "test")
+  term(solutionFilePath, "test", "")
 end
 
 

--- a/lua/easy-dotnet/ef-core/database.lua
+++ b/lua/easy-dotnet/ef-core/database.lua
@@ -40,9 +40,6 @@ M.database_update = function(mode)
 
   spinner:start_spinner("Applying migrations")
   vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data)
-
-    end,
     on_exit = function(_, code)
       if code == 0 then
         spinner:stop_spinner("Database updated")

--- a/lua/easy-dotnet/ui-modules/spinner.lua
+++ b/lua/easy-dotnet/ui-modules/spinner.lua
@@ -4,9 +4,10 @@ M.__index = M
 
 ---Spinner symbol presets
 M.spinner_presets = {
-  default = { '-', '\\', '|', '/' },
+  default = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
+  lines = { '-', '\\', '|', '/' },
   dots = { '.', '..', '...', '....' },
-  arrows = { '→', '↘', '↓', '↙', '←', '↖', '↑', '↗' }
+  arrows = { '→', '↘', '↓', '↙', '←', '↖', '↑', '↗' },
 }
 
 ---Creates a new spinner instance.


### PR DESCRIPTION
Using string format with the %s will cause nil to be interpreted literally.
This resulted in some commands being called with nil argument, propagating into the terminal command and causing it to fail.