### PR TITLE
feat(cmp): add package autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Using nvim-cmp
 
 >[!NOTE]
 >Latest is added as a snippet to make it easier to select the latest version
+
 ![image](https://github.com/user-attachments/assets/2b59735f-941e-44d2-93cf-76b13ac3e76f)
 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
    - [Requirements](#requirements)
 9. [Csproj mappings](#csproj-mappings)
    - [Add reference](#add-reference)
+   - [Package autocomplete](#package-autocomplete)
 10. [New](#new)
     - [Project](#project)
     - [Configuration file](#configuration-file)
@@ -55,8 +56,13 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 - Outdated command: Makes checking outdated packages a breeze using virtual text
 - Csproj mappings: Keymappings for .csproj files are automatically available
 - Create dotnet templates like with `dotnet new`
+- Package autocomplete inside .csproj files [Check it out](#package-autocomplete)
 
 ## Setup
+
+
+>[!IMPORTANT]
+>Remember to also setup the cmp source for autocomplete
 
 ### Without options
 ```lua
@@ -231,6 +237,23 @@ Key mappings are available automatically within `.csproj` files
 `<leader>ar` -> Opens a telescope picker for selecting which project reference to add
 
 ![image](https://github.com/user-attachments/assets/dec096be-8a87-4dd8-aaec-8c22849d1640)
+
+### Package autocomplete
+When editing package references inside a .csproject file it is possible to enable autocomplete.
+This will trigger autocomplete for `<PackageReference Include="<cmp-trigger>" />`
+
+Using nvim-cmp
+```lua
+    cmp.register_source("easy-dotnet", require("easy-dotnet").package_completion_source)
+    ...
+    sources = cmp.config.sources({
+        { name = 'nvim_lsp'    },
+        { name = 'easy-dotnet' },
+        ...
+    }),
+    ...
+```
+
 
 ## New
 Create dotnet templates as with `dotnet new <templatename>`

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Key mappings are available automatically within `.csproj` files
 
 ### Package autocomplete
 When editing package references inside a .csproject file it is possible to enable autocomplete.
-This will trigger autocomplete for `<PackageReference Include="<cmp-trigger>" />`
+This will trigger autocomplete for `<PackageReference Include="<cmp-trigger>" Version="<cmp-trigger>" />`
 
 Using nvim-cmp
 ```lua

--- a/README.md
+++ b/README.md
@@ -253,8 +253,13 @@ Using nvim-cmp
     }),
     ...
 ```
-![image](https://github.com/user-attachments/assets/ab11c92e-3d97-4dc6-bbc2-ab7bba7ce899)
-![image](https://github.com/user-attachments/assets/261434ca-d42c-421f-8ee5-8dc22b441597)
+![image](https://github.com/user-attachments/assets/81809aa8-704b-4481-9445-3985ddef6c98)
+
+>[!NOTE]
+>Latest is added as a snippet to make it easier to select the latest version
+![image](https://github.com/user-attachments/assets/2b59735f-941e-44d2-93cf-76b13ac3e76f)
+
+
 
 
 ## New

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Key mappings are available automatically within `.csproj` files
 ### Package autocomplete
 When editing package references inside a .csproject file it is possible to enable autocomplete.
 This will trigger autocomplete for `<PackageReference Include="<cmp-trigger>" Version="<cmp-trigger>" />`
+This functionality relies on `jq` so ensure that is installed on your system.
 
 Using nvim-cmp
 ```lua
@@ -259,9 +260,6 @@ Using nvim-cmp
 >Latest is added as a snippet to make it easier to select the latest version
 
 ![image](https://github.com/user-attachments/assets/2b59735f-941e-44d2-93cf-76b13ac3e76f)
-
-
-
 
 ## New
 Create dotnet templates as with `dotnet new <templatename>`

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Using nvim-cmp
     }),
     ...
 ```
+![image](https://github.com/user-attachments/assets/ab11c92e-3d97-4dc6-bbc2-ab7bba7ce899)
+![image](https://github.com/user-attachments/assets/261434ca-d42c-421f-8ee5-8dc22b441597)
 
 
 ## New

--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -74,9 +74,7 @@ M.package_completion_cmp = {
   complete = function(_, _, callback)
     local _, col = unpack(vim.api.nvim_win_get_cursor(0))
     local current_line = vim.api.nvim_get_current_line()
-
     local before_cursor = current_line:sub(1, col)
-
     local pattern_before = 'Include="[^"]*$'
 
     local inside_include = before_cursor:match(pattern_before)
@@ -88,7 +86,6 @@ M.package_completion_cmp = {
           search_term), {
           stdout_buffered = true,
           on_stdout = function(_, data)
-            print(vim.inspect(data))
             local items = vim.tbl_map(function(i)
               return { label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', "") }
             end, data)

--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -85,12 +85,12 @@ M.package_completion_cmp = {
       local search_term = inside_include:gsub('%Include="', "")
       vim.fn.jobstart(
         string.format(
-          "dotnet package search %s --take 2 --format json | jq '.searchResult | .[] | .packages | .[] | .id'",
+          "dotnet package search %s --take 5 --format json | jq '.searchResult | .[] | .packages | .[] | .id'",
           search_term), {
           stdout_buffered = true,
           on_stdout = function(_, data)
             local items = vim.tbl_map(function(i)
-              return { label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', "") }
+              return { label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', ""), kind = 18 }
             end, data)
             callback({ items = items, isIncomplete = true })
           end,
@@ -112,7 +112,8 @@ M.package_completion_cmp = {
                 label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', ""),
                 deprecated = true,
                 sortText = "",
-                preselect = index == last_index
+                preselect = index == last_index,
+                kind = 12
               }
               if index == last_index then
                 latest = cmp_item.label
@@ -123,7 +124,9 @@ M.package_completion_cmp = {
             if latest then
               table.insert(items, {
                 label = "latest",
-                insertText = latest
+                insertText = latest,
+                kind = 15,
+                preselect = true
               })
             end
             callback({ items = items, isIncomplete = false })

--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -103,9 +103,29 @@ M.package_completion_cmp = {
         {
           stdout_buffered = true,
           on_stdout = function(_, data)
+            local index = 0
+            local latest = nil
+            local last_index = #data - 1
             local items = vim.tbl_map(function(i)
-              return { label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', "") }
+              index = index + 1
+              local cmp_item = {
+                label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', ""),
+                deprecated = true,
+                sortText = "",
+                preselect = index == last_index
+              }
+              if index == last_index then
+                latest = cmp_item.label
+              end
+              return cmp_item
             end, data)
+
+            if latest then
+              table.insert(items, {
+                label = "latest",
+                insertText = latest
+              })
+            end
             callback({ items = items, isIncomplete = false })
           end,
         })

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -208,4 +208,6 @@ M.is_dotnet_project = function()
   return project_files ~= nil
 end
 
+M.package_completion_source = require("easy-dotnet.csproj-mappings").package_completion_cmp
+
 return M


### PR DESCRIPTION
Adds autocomplete to `<PackageReference Include="<here>" Version="<here>"`.
This relies on `dotnet package search` and `jq`

Partly implements: #124

![image](https://github.com/user-attachments/assets/81809aa8-704b-4481-9445-3985ddef6c98)
![image](https://github.com/user-attachments/assets/2b59735f-941e-44d2-93cf-76b13ac3e76f)


