### PR TITLE
feat(testrunner):🧪🎁 keybind to debug test using nvim-dap

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Integrated test runner inspired by Rider IDE
 - `E` -> Expand all
 - `o` -> Expand/collapse under cursor
 - `<leader>r` -> Run test under cursor
+- `<leader>d` -> `[Experimental]` Debug test under cursor using nvim-dap
 - `<leader>R` -> Run all tests
 - `<leader>p` -> Peek stacktrace on failed test
 - `<leader>fe` -> Show only failed tests

--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ Integrated test runner inspired by Rider IDE
 - `g` -> Go to file
 - `q` -> Close window
 
+### Debugging tests
+Using the keybinding `<leader>d` will set a breakpoint in the test and launch nvim-dap
+
+https://github.com/user-attachments/assets/b56891c9-1b65-4522-8057-43eff3d1102d
+
 ## Outdated
 
 Run the command `Dotnet outdated` in a .csproj file, virtual text with packages latest version will appear

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -26,6 +26,7 @@ local function run_job_sync(cmd)
   vim.fn.jobstart(cmd, {
     stdout_buffered = false,
     on_stdout = function(_, data, _)
+      -- print(vim.inspect(data))
       for _, line in ipairs(data) do
         local match = string.match(line, "Process Id: (%d+)")
         if match then
@@ -34,6 +35,9 @@ local function run_job_sync(cmd)
           return
         end
       end
+    end,
+    on_stderr = function(_, data)
+      -- print(vim.inspect(data))
     end,
     on_exit = function(_, code)
       --TODO: could catch and update testrestult here

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -34,6 +34,9 @@ local function run_job_sync(cmd)
           return
         end
       end
+    end,
+    on_exit = function(_, code)
+      --TODO: could catch and update testrestult here
     end
   })
 

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -34,7 +34,7 @@ local function run_job_sync(cmd)
           return
         end
       end
-    end,
+    end
   })
 
   coroutine.yield()
@@ -42,6 +42,7 @@ local function run_job_sync(cmd)
   return result
 end
 
+---@param path string
 local function start_test_process(path)
   local command = string.format("dotnet test %s --environment=VSTEST_HOST_DEBUG=1", path)
   local res = run_job_sync(command)
@@ -52,20 +53,20 @@ local function start_test_process(path)
 end
 
 
-M.start_debugging_test_project = function()
+M.start_debugging_test_project = function(project_path)
   local sln_file = sln_parse.find_solution_file()
-  assert(sln_file, "Failed to find a solution filej")
+  assert(sln_file, "Failed to find a solution file")
   local projects = sln_parse.get_projects_from_sln(sln_file)
   local test_projects = extensions.filter(projects, function(i)
     return i.isTestProject
   end)
-  local test_project = picker.pick_sync(nil, test_projects, "Pick test project")
+  local test_project = project_path and project_path or picker.pick_sync(nil, test_projects, "Pick test project").path
   assert(test_project, "No project selected")
 
-  local process_id = start_test_process(vim.fs.dirname(test_project.path))
+  local process_id = start_test_process(test_project)
   return {
     process_id = process_id,
-    cwd = test_project.path
+    cwd = vim.fs.dirname(test_project)
   }
 end
 

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -373,7 +373,7 @@ local keymaps = {
       request = "attach",
       processId = function()
         local project_path = line.cs_project_path
-        local res = require("easy-dotnet").experimental.start_debugging_test_project(project_path)
+        local res = require("easy-dotnet.debugger").start_debugging_test_project(project_path)
         return res.process_id
       end
     }

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -357,10 +357,13 @@ local keymaps = {
       vim.notify("Debugging is only supported for tests and test_groups")
       return
     end
-    local dap = require("dap")
+    local success, dap = pcall(function() return require("dap") end)
+    if not success then
+      vim.notify("nvim-dap not installed", vim.log.levels.ERROR)
+      return
+    end
     vim.cmd("Dotnet testrunner")
     vim.cmd("edit " .. line.file_path)
-    print(vim.inspect(line))
     vim.api.nvim_win_set_cursor(0, { line.line_number and (line.line_number - 1) or 0, 0 })
     dap.toggle_breakpoint()
 

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -347,6 +347,7 @@ local function expand_section(line, index, win)
   win.refreshLines()
 end
 
+
 local keymaps = {
   ["<leader>fe"] = function(_, _, win)
     filter_failed_tests(win)
@@ -362,20 +363,19 @@ local keymaps = {
     print(vim.inspect(line))
     vim.api.nvim_win_set_cursor(0, { line.line_number and (line.line_number - 1) or 0, 0 })
     dap.toggle_breakpoint()
-    dap.configurations["cs"] = {
-      {
-        type = "coreclr",
-        name = line.name,
-        request = "attach",
-        processId = function()
-          local project_path = line.cs_project_path
-          local res = require("easy-dotnet").experimental.start_debugging_test_project(project_path)
-          return res.process_id
-        end
-      }
+
+    local dap_configuration = {
+      type = "coreclr",
+      name = line.name,
+      request = "attach",
+      processId = function()
+        local project_path = line.cs_project_path
+        local res = require("easy-dotnet").experimental.start_debugging_test_project(project_path)
+        return res.process_id
+      end
     }
 
-    dap.continue()
+    dap.run(dap_configuration)
   end,
   ---@param line Test
   ["g"] = function(_, line, win)


### PR DESCRIPTION
Testing out being able to start the nvim-dap debugger directly from the testrunner with keybind `<leader>d`

This will do the following

1. Close testrunner
2. Open selected testfile
3. Set breakpoint on the first line in the function
4. Dynamically register a dap config for this test
5. profit???

https://github.com/user-attachments/assets/b56891c9-1b65-4522-8057-43eff3d1102d


