### PR TITLE
fix: dont crash on missing package 🐛

### DIFF
--- a/lua/easy-dotnet/outdated/outdated.lua
+++ b/lua/easy-dotnet/outdated/outdated.lua
@@ -72,14 +72,15 @@ M.outdated = function()
           local ns_id = require("easy-dotnet.constants").ns_id
           for _, value in ipairs(deps) do
             local line = find_package_reference_in_buffer(value.Name)
-            if line == nil then
-              error("Failed to find package " .. value.Name)
+            if line ~= nil then
+              vim.api.nvim_buf_set_extmark(bnr, ns_id, line - 1, 0, {
+                virt_text = { { string.format("%s -> %s", value.ResolvedVersion, value.LatestVersion), "EasyDotnetPackage" } },
+                virt_text_pos = "eol",
+                priority = 200,
+              })
+            else
+              vim.notify("Failed to find package " .. value.Name, vim.log.levels.DEBUG)
             end
-            vim.api.nvim_buf_set_extmark(bnr, ns_id, line - 1, 0, {
-              virt_text = { { string.format("%s -> %s", value.ResolvedVersion, value.LatestVersion), "EasyDotnetPackage" } },
-              virt_text_pos = "eol",
-              priority = 200,
-            })
           end
         else
           vim.notify("Dotnet outdated tool not installed")


### PR DESCRIPTION
Made a debug notification instead of crashing as `dotnet outdated` will also pull packages from the `Directory.Packages.props` file. 

Thus it will be very understanding that the plugin cannot find the package in the csproj.