### PR TITLE
fix(dll-path):🐛 path issues on unix

### DIFF
--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -136,7 +136,10 @@ M.get_project_from_project_file = function(project_file_path)
               project_file_path)))
           .Properties
       local target = string.format("%s%s", value.AssemblyName, value.TargetExt)
-      local path = vim.fs.joinpath(vim.fs.dirname(project_file_path), value.OutputPath:gsub("\\", "/"), target)
+      --https://github.com/GustavEikaas/easy-dotnet.nvim/issues/143
+      local path = extensions.isWindows() and
+          vim.fs.joinpath(vim.fs.dirname(project_file_path), value.OutputPath:gsub("\\", "/"), target) or
+          vim.fs.joinpath(value.OutputPath, target)
       local msbuild_target_framework = value.TargetFramework:gsub("%net", "")
 
       c["version"] = msbuild_target_framework

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -136,12 +136,12 @@ M.get_project_from_project_file = function(project_file_path)
               project_file_path)))
           .Properties
       local target = string.format("%s%s", value.AssemblyName, value.TargetExt)
-      --https://github.com/GustavEikaas/easy-dotnet.nvim/issues/143
-      local path = extensions.isWindows() and
-          vim.fs.joinpath(vim.fs.dirname(project_file_path), value.OutputPath:gsub("\\", "/"), target) or
-          vim.fs.joinpath(value.OutputPath, target)
-      local msbuild_target_framework = value.TargetFramework:gsub("%net", "")
 
+      --https://github.com/GustavEikaas/easy-dotnet.nvim/issues/143
+      local path = value.OutputPath:sub(1, 1) == "/" and vim.fs.joinpath(value.OutputPath, target) or
+          vim.fs.joinpath(vim.fs.dirname(project_file_path), value.OutputPath:gsub("\\", "/"), target)
+
+      local msbuild_target_framework = value.TargetFramework:gsub("%net", "")
       c["version"] = msbuild_target_framework
       c["dll_path"] = path
       return path


### PR DESCRIPTION
~Msbuild behaves differently on unix and windows when querying the build property `OutputPath` on Windows its relative but on unix its absolute~