### PR TITLE
fix:🐛 launch_with_profile crash on no launchSettings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ https://github.com/user-attachments/assets/b56891c9-1b65-4522-8057-43eff3d1102d
 
 ## Outdated
 
-Run the command `Dotnet outdated` in a .csproj file, virtual text with packages latest version will appear
+Run the command `Dotnet outdated` in a `*.csproj`, `Directory.Packages.props` or `Packages.props` file, virtual text with packages latest version will appear
 
 ![image](https://github.com/user-attachments/assets/496caec1-a18b-487a-8a37-07c4bb9fa113)
 

--- a/lua/easy-dotnet/actions/run.lua
+++ b/lua/easy-dotnet/actions/run.lua
@@ -94,7 +94,7 @@ local function pick_profile(project)
     return table.concat(vim.fn.readfile(path), "\n")
   end)
   if not success then
-    vim.notify("No launchSettings file found", vim.log.levels.WARN)
+    vim.notify("No launchSettings file found", vim.log.levels.DEBUG)
     return nil
   end
 


### PR DESCRIPTION
Fixed a bug where `run_with_profile` would crash if no launchSettings.json file is found 