### PR TITLE
fix:🐛 windows path parsing

### DIFF
--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -8,7 +8,7 @@
 local function get_sdk_path()
   local sdk_version = vim.system({ "dotnet", "--version" }):wait().stdout:gsub("\r", ""):gsub("\n", "")
   local isWindows = require("easy-dotnet.extensions").isWindows()
-  local base = isWindows and "C:/Program Files/dotnet/sdk" or "/usr/lib/dotnet/sdk"
+  local base = isWindows and 'C:/"Program Files"/dotnet/sdk' or "/usr/lib/dotnet/sdk"
   local sdk_path = vim.fs.joinpath(base, sdk_version)
   return sdk_path
 end

--- a/lua/easy-dotnet/outdated/outdated.lua
+++ b/lua/easy-dotnet/outdated/outdated.lua
@@ -71,7 +71,7 @@ local function find_package_reference_in_buffer(package_name)
 end
 
 M.outdated = function()
-  local path = vim.fn.expand("%")
+  local path = vim.fs.normalize(vim.fn.expand("%"))
   local filename = vim.fs.basename(path):lower()
   if path:match(".csproj$") then
     local project_name = vim.fs.basename(path:match("([^/]+)%.csproj$"))

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -104,7 +104,7 @@ local function run_csproject(win, cs_project_path)
 
   win.refreshLines()
   vim.fn.jobstart(
-    string.format("dotnet test --nologo %s %s --logger='trx;logFileName=%s'", get_dotnet_args(win.options),
+    string.format( "dotnet test --nologo %s %s --logger=trx;logFileName=%s", get_dotnet_args(win.options),
       cs_project_path,
       log_file_name), {
       on_exit = function(_, code)
@@ -137,7 +137,7 @@ local function run_test_group(line, win)
 
   local on_job_finished = win.appendJob(line.name, "Run", testcount)
   vim.fn.jobstart(
-    string.format("dotnet test --filter='%s' --nologo %s %s --logger='trx;logFileName=%s'",
+    string.format( "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
       suite_name, get_dotnet_args(win.options), line.cs_project_path, log_file_name),
     {
       on_exit = function()
@@ -171,7 +171,7 @@ local function run_test_suite(line, win)
 
   local on_job_finished = win.appendJob(line.namespace, "Run", testcount)
   vim.fn.jobstart(
-    string.format("dotnet test --filter='%s' --nologo %s %s --logger='trx;logFileName=%s'",
+    string.format( "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
       suite_name, get_dotnet_args(win.options), line.cs_project_path, log_file_name),
     {
       on_exit = function()
@@ -233,7 +233,7 @@ local function run_test(line, win)
   local relative_log_file_path = vim.fs.joinpath(directory_path, "TestResults", log_file_name)
 
   local command = string.format(
-    "dotnet test --filter='%s' --nologo %s %s --logger='trx;logFileName=%s'",
+    "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
     line.namespace:gsub("%b()", ""), get_dotnet_args(win.options), line.cs_project_path, log_file_name)
 
   local on_job_finished = win.appendJob(line.name, "Run")

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -104,7 +104,7 @@ local function run_csproject(win, cs_project_path)
 
   win.refreshLines()
   vim.fn.jobstart(
-    string.format( "dotnet test --nologo %s %s --logger=trx;logFileName=%s", get_dotnet_args(win.options),
+    string.format( 'dotnet test --nologo %s %s --logger="trx;logFileName=%s"', get_dotnet_args(win.options),
       cs_project_path,
       log_file_name), {
       on_exit = function(_, code)
@@ -137,7 +137,7 @@ local function run_test_group(line, win)
 
   local on_job_finished = win.appendJob(line.name, "Run", testcount)
   vim.fn.jobstart(
-    string.format( "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
+    string.format( 'dotnet test --filter=%s --nologo %s %s --logger="trx;logFileName=%s"',
       suite_name, get_dotnet_args(win.options), line.cs_project_path, log_file_name),
     {
       on_exit = function()
@@ -171,7 +171,7 @@ local function run_test_suite(line, win)
 
   local on_job_finished = win.appendJob(line.namespace, "Run", testcount)
   vim.fn.jobstart(
-    string.format( "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
+    string.format( 'dotnet test --filter=%s --nologo %s %s --logger="trx;logFileName=%s"',
       suite_name, get_dotnet_args(win.options), line.cs_project_path, log_file_name),
     {
       on_exit = function()
@@ -233,7 +233,7 @@ local function run_test(line, win)
   local relative_log_file_path = vim.fs.joinpath(directory_path, "TestResults", log_file_name)
 
   local command = string.format(
-    "dotnet test --filter=%s --nologo %s %s --logger=trx;logFileName=%s",
+    'dotnet test --filter=%s --nologo %s %s --logger="trx;logFileName=%s"',
     line.namespace:gsub("%b()", ""), get_dotnet_args(win.options), line.cs_project_path, log_file_name)
 
   local on_job_finished = win.appendJob(line.name, "Run")

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -155,10 +155,10 @@ local default_options = require("easy-dotnet.options").test_runner
 local function discover_tests_for_project_and_update_lines(project, win, options, dotnet_project, sdk_path,
                                                            on_job_finished)
   local vstest_dll = vim.fs.joinpath(sdk_path, "vstest.console.dll")
-  local absolute_dll_path = vim.fs.joinpath(vim.fn.getcwd(), dotnet_project.get_dll_path())
-  local outfile = os.tmpname()
+  local absolute_dll_path = vim.fs.normalize(vim.fs.joinpath(vim.fn.getcwd(), dotnet_project.get_dll_path()))
+  local outfile = vim.fs.normalize(os.tmpname())
   local script_path = require("easy-dotnet.test-runner.discovery").get_script_path()
-  local command = string.format("dotnet fsi %s '%s' '%s' '%s'", script_path, vstest_dll,
+  local command = string.format("dotnet fsi %s %s %s %s", script_path, vstest_dll,
     absolute_dll_path, outfile)
 
   local tests = {}

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -92,8 +92,8 @@ end
 ---@param xml_path string
 M.xml_to_json = function(xml_path, cb)
   local fsx_file = ensure_and_get_fsx_path()
-  local outfile = os.tmpname()
-  local command = string.format("dotnet fsi %s '%s' %s", fsx_file, xml_path, outfile)
+  local outfile = vim.fs.normalize(os.tmpname())
+  local command = string.format("dotnet fsi %s %s %s", fsx_file, xml_path, outfile)
   ---@type TestCase[]
   local tests = {}
   vim.fn.jobstart(command, {


### PR DESCRIPTION
improvement for windows support:
* normalization of paths obtained via nvim api to always use `/`, which is supported in both linux and windows.
* removal of quotes where not really needed
    - exception for `dotnet test ... --logger="trx;logFileName=%s"` where using double quotes  is the only option supported by both linux and windows