### PR TITLE
Testrunner fix for dotnet 5

### DIFF
--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local file_template = [[
-//v3
+//v4
 #r "nuget: Newtonsoft.Json"
 open System
 open System.IO
@@ -19,7 +19,7 @@ let transformTestCase (testCase: JObject) : JProperty =
     let testId = testCase.["@testId"].ToString()
     let newTestCase = new JObject()
     newTestCase.["outcome"] <- testCase.["@outcome"]
-    newTestCase.["id"] <- testId
+    newTestCase.["id"] <- testCase.["@testId"]
 
     let errorInfo = testCase.SelectToken("$.Output.ErrorInfo")
     if errorInfo <> null && errorInfo.["StackTrace"] <> null then


### PR DESCRIPTION
Hi, after the #164 fix, another issue has arisen. If you take the repro from the linked issue and replace `dotnet8` with `dotnet5` (you should replace `ClassicAssert` with `Assert` as well), there will be another error in the F# script:

```
test_parser.fsx(19,5): error FS0041: No overloads match for method 'Item'.

Known types of arguments: string * string

Available overloads:
 - JObject.set_Item(propertyName: string, value: JToken) : unit // Argument 'value' doesn't match
 - JToken.set_Item(key: obj, value: JToken) : unit // Argument 'value' doesn't match
```

My installed SDKs are:

```
5.0.408
8.0.303
```

So, on `dotnet5`, `JObject` can accept only `JValue`, while on `dotnet8` it also accepts `String`. It was a minor refactoring, so let's revert this line so the script can work on both `dotnet` versions.