### PR TITLE
feat(dotnet new):🎁 nvim-tree integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,17 +352,27 @@ If a configuration file is selected it will
 Adding the following configuration to your nvim-tree will allow for creating files using dotnet templates
 
 ```lua
-vim.keymap.set('n', 'A', function()
-  local function co_wrapper()
-    local node = api.tree.get_node_under_cursor()
-    local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
+    require("nvim-tree").setup({
+      on_attach = function(bufnr)
+        local api = require('nvim-tree.api')
 
-    require("easy-dotnet").create_new_item(path)
-  end
+        local function opts(desc)
+          return { desc = 'nvim-tree: ' .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+        end
 
-  local co = coroutine.create(co_wrapper)
-  coroutine.resume(co)
-end, opts('Create file from dotnet template'))
+        vim.keymap.set('n', 'A', function()
+          local function co_wrapper()
+            local node = api.tree.get_node_under_cursor()
+            local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
+
+            require("easy-dotnet").create_new_item(path)
+          end
+
+          local co = coroutine.create(co_wrapper)
+          coroutine.resume(co)
+        end, opts('Create file from dotnet template'))
+      end
+    })
 ```
 
 ## EntityFramework

--- a/README.md
+++ b/README.md
@@ -361,15 +361,9 @@ Adding the following configuration to your nvim-tree will allow for creating fil
         end
 
         vim.keymap.set('n', 'A', function()
-          local function co_wrapper()
-            local node = api.tree.get_node_under_cursor()
-            local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
-
-            require("easy-dotnet").create_new_item(path)
-          end
-
-          local co = coroutine.create(co_wrapper)
-          coroutine.resume(co)
+          local node = api.tree.get_node_under_cursor()
+          local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
+          require("easy-dotnet").create_new_item(path)
         end, opts('Create file from dotnet template'))
       end
     })

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 10. [New](#new)
     - [Project](#project)
     - [Configuration file](#configuration-file)
+    - [Integrating with nvim-tree](#integrating-with-nvim-tree)
 11. [EntityFramework](#entityframework)
     - [Database](#database)
     - [Migrations](#migrations)
@@ -345,6 +346,24 @@ https://github.com/user-attachments/assets/aa067c17-3611-4490-afc8-41d98a526729
 
 If a configuration file is selected it will
 1. Create the configuration file and place it next to your solution file. (solution files and gitignore files are placed in cwd)
+
+### Integrating with nvim-tree
+
+Adding the following configuration to your nvim-tree will allow for creating files using dotnet templates
+
+```lua
+vim.keymap.set('n', 'A', function()
+  local function co_wrapper()
+    local node = api.tree.get_node_under_cursor()
+    local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
+
+    require("easy-dotnet").create_new_item(path)
+  end
+
+  local co = coroutine.create(co_wrapper)
+  coroutine.resume(co)
+end, opts('Create file from dotnet template'))
+```
 
 ## EntityFramework
 Common EntityFramework commands have been added mainly to reduce the overhead of writing `--project .. --startup-project ..`. 

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -301,6 +301,8 @@ M.create_new_item = function(path)
       { value = "buildprops",     display = "MSBuild Directory.Build.props File",   type = "MSBuild/props" },
       { value = "buildtargets",   display = "MSBuild Directory.Build.targets File", type = "MSBuild/props" },
       { value = "apicontroller",  display = "Api Controller",                       type = "Code" },
+      { value = "interface",      display = "Interface",                            type = "Code" },
+      { value = "class",          display = "Class",                                type = "Code" },
       { value = "mvccontroller",  display = "MVC Controller",                       type = "Code" },
       { value = "viewimports",    display = "MVC ViewImports",                      type = "Code" },
       { value = "viewstart",      display = "MVC ViewStart",                        type = "Code" },

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -323,9 +323,8 @@ M.create_new_item = function(path)
   local args = ""
 
   if template.type == "Code" then
-    local namespace = "Will.Calculate"
     local name = name_input_sync()
-    args = string.format("--namespace %s -n %s", namespace, name)
+    args = string.format("-n %s", name)
   elseif template.type == "MSBuild/props" then
   elseif template.type == "Config" then
     local name = name_input_sync()
@@ -337,6 +336,11 @@ M.create_new_item = function(path)
 
   local cmd = string.format("dotnet new %s -o %s %s", template.value, path, args)
   vim.fn.jobstart(cmd, {
+    on_stderr = function(_, data)
+      for _, value in ipairs(data) do
+        vim.notify(value, vim.log.levels.ERROR)
+      end
+    end,
     on_exit = function(_, code)
       if code == 0 then
         vim.notify("Success")

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -307,13 +307,12 @@ M.create_new_item = function(path)
       { value = "razorcomponent", display = "Razor Component",                      type = "Code" },
       { value = "page",           display = "Razor Page",                           type = "Code" },
       { value = "view",           display = "Razor View",                           type = "Code" },
+      { value = "nunit-test",     display = "NUnit 3 Test Item",                    type = "Test/NUnit" },
       { value = "gitignore",      display = "Dotnet Gitignore File",                type = "Config" },
       { value = "tool-manifest",  display = "Dotnet Local Tool Manifest File",      type = "Config" },
       { value = "editorconfig",   display = "EditorConfig File",                    type = "Config" },
       { value = "globaljson",     display = "Global.json File",                     type = "Config" },
       { value = "nugetconfig",    display = "NuGet Config",                         type = "Config" },
-      { value = "nunit-test",     display = "NUnit 3 Test Item",                    type = "Test/NUnit" },
-      { value = "proto",          display = "Protocol Buffer File",                 type = "Web/gRPC" },
       { value = "webconfig",      display = "Web Config",                           type = "Config" },
       { value = "solution",       display = "Solution",                             type = "Config" }
     },
@@ -328,8 +327,10 @@ M.create_new_item = function(path)
     local name = name_input_sync()
     args = string.format("--namespace %s -n %s", namespace, name)
   elseif template.type == "MSBuild/props" then
-    --Do nothing
   elseif template.type == "Config" then
+    local name = name_input_sync()
+    args = string.format("-n %s", name)
+  elseif template.type == "Test/NUnit" then
     local name = name_input_sync()
     args = string.format("-n %s", name)
   end

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -345,7 +345,6 @@ M.create_new_item = function(path)
     end,
     on_exit = function(_, code)
       if code == 0 then
-        vim.notify("Success")
       else
         vim.notify("Command failed")
       end

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -223,6 +223,7 @@ M.setup = function(opts)
   end
 
   M.restore = commands.restore
+  M.create_new_item = require("easy-dotnet.actions.new").create_new_item
   M.secrets = commands.secrets
   M.build = commands.build
   M.clean = commands.clean

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -1,5 +1,19 @@
 local M = {}
 
+local function wrap(callback)
+  return function(...)
+    -- Check if we are already in a coroutine
+    if coroutine.running() then
+      -- If already in a coroutine, call the callback directly
+      callback(...)
+    else
+      -- If not, create a new coroutine and resume it
+      local co = coroutine.create(callback)
+      coroutine.resume(co, ...)
+    end
+  end
+end
+
 local options = require("easy-dotnet.options")
 local actions = require("easy-dotnet.actions")
 local secrets = require("easy-dotnet.secrets")
@@ -223,7 +237,11 @@ M.setup = function(opts)
   end
 
   M.restore = commands.restore
-  M.create_new_item = require("easy-dotnet.actions.new").create_new_item
+
+  M.create_new_item = wrap(function(...)
+    require("easy-dotnet.actions.new").create_new_item(...)
+  end)
+
   M.secrets = commands.secrets
   M.build = commands.build
   M.clean = commands.clean


### PR DESCRIPTION
Code and example for integrating `dotnet new` into nvim-tree, oil.nvim etc.. 
Will allow for creating api controllers, solution files, web.config etc from the tree


nvim-tree code
```lua
vim.keymap.set('n', 'A', function()
    local node = api.tree.get_node_under_cursor()
    local path = node.type == "directory" and node.absolute_path or vim.fs.dirname(node.absolute_path)
    require("easy-dotnet").create_new_item(path)
end, opts('Create file from dotnet template'))
```
