### PR TITLE
chore: remove unused code

### DIFF
--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -297,7 +297,6 @@ local function refresh_runner(options, win, solutionFilePath, sdk_path)
       ---@type Test
       local project = {
         id = "",
-        collapsble = true,
         cs_project_path = value.path,
         solution_file_path = solutionFilePath,
         namespace = "",


### PR DESCRIPTION
seems to be a typo here, because the field with the correct name `collapsable` is set below