### PR TITLE
feat: use dotnet cli to find sdk path

### DIFF
--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -39,9 +39,15 @@
 ---@field additional_args table
 
 local function get_sdk_path()
-  local sdk_version = vim.system({ "dotnet", "--version" }):wait().stdout:gsub("\r", ""):gsub("\n", "")
-  local isWindows = require("easy-dotnet.extensions").isWindows()
-  local base = isWindows and 'C:/"Program Files"/dotnet/sdk' or "/usr/lib/dotnet/sdk"
+  local sdk_version = vim.trim(vim.system({ "dotnet", "--version" }):wait().stdout)
+  local sdk_list = vim.trim(vim.system({ "dotnet", "--list-sdks" }):wait().stdout)
+  local base = nil
+  for line in sdk_list:gmatch("[^\n]+") do
+    if line:find(sdk_version, 1, true) then
+      base = line:match("%[(.-)%]")
+      break
+    end
+  end
   local sdk_path = vim.fs.joinpath(base, sdk_version)
   return sdk_path
 end


### PR DESCRIPTION
This should improve the default experience for users where the SDKs are installed somewhere other than `/usr/lib/dotnet/sdk/` or `C:\Program Files\dotnet\sdk\`.

To find the SDK path we use the `dotnet --list-sdks` and look for the SDK matching the dotnet version.

I have only tested the changes on Linux, but it should still work on Windows and Mac as the `dotnet --list-sdks` command is cross platform.

resolves #146