### PR TITLE
feat(testrunner):🎁 improve stacktrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Dotnet run|test|build --no-build --no-restore -c prerelease
 
 Integrated test runner inspired by Rider IDE
 ![image](https://github.com/user-attachments/assets/874a1ef1-18cb-43f6-a477-834a783cf785)
-![image](https://github.com/user-attachments/assets/fdc01dbd-4a6a-47be-965e-a4b9c9ae910c)
+![image](https://github.com/user-attachments/assets/2d0512f3-f807-4fbd-bf64-a57eb3c06b18)
 
 - [x] Basic test runner window
   - [x] Grouped by namespace

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ Dotnet run|test|build --no-build --no-restore -c prerelease
 ## Testrunner
 
 Integrated test runner inspired by Rider IDE
-![image](https://github.com/user-attachments/assets/0f9396ac-6827-4edf-b063-a178ea09a2b2)
-![image](https://github.com/user-attachments/assets/5fd297c6-7df5-4cf5-9ba7-5a196e8f24ee)
+![image](https://github.com/user-attachments/assets/874a1ef1-18cb-43f6-a477-834a783cf785)
+![image](https://github.com/user-attachments/assets/fdc01dbd-4a6a-47be-965e-a4b9c9ae910c)
 
 - [x] Basic test runner window
   - [x] Grouped by namespace

--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -31,7 +31,7 @@ local function parse_status(result, test_line, options)
     test_line.icon = options.icons.passed
   elseif result.outcome == "Failed" then
     test_line.icon = options.icons.failed
-    test_line.expand = vim.split(result.stackTrace, "\n")
+    test_line.expand = vim.split(result.message .. "\n" .. result.stackTrace:gsub("^%s+", ""):gsub("\n%s+", "\n"), "\n")
   elseif result.outcome == "NotExecuted" then
     test_line.icon = options.icons.skipped
   else

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local file_template = [[
-//v4
+//v5
 #r "nuget: Newtonsoft.Json"
 open System
 open System.IO
@@ -24,6 +24,9 @@ let transformTestCase (testCase: JObject) : JProperty =
     let errorInfo = testCase.SelectToken("$.Output.ErrorInfo")
     if errorInfo <> null && errorInfo.["StackTrace"] <> null then
         newTestCase.["stackTrace"] <- errorInfo.["StackTrace"]
+    if errorInfo <> null && errorInfo.["Message"] <> null then
+        newTestCase.["message"] <- errorInfo.["Message"]
+
 
     new JProperty(testId, newTestCase)
 
@@ -95,6 +98,7 @@ end
 --- @class TestCase
 --- @field id string
 --- @field stackTrace string | nil
+--- @field message string | nil
 --- @field outcome TestResult
 
 ---@param xml_path string

--- a/lua/easy-dotnet/test-runner/test-parser.lua
+++ b/lua/easy-dotnet/test-runner/test-parser.lua
@@ -27,7 +27,6 @@ let transformTestCase (testCase: JObject) : JProperty =
     if errorInfo <> null && errorInfo.["Message"] <> null then
         newTestCase.["message"] <- errorInfo.["Message"]
 
-
     new JProperty(testId, newTestCase)
 
 let extractAndTransformResults (jsonObj: JObject) : JObject option =


### PR DESCRIPTION
Previously the stacktrace was shown but not the message. With this change the stacktrace should be easier to read because it tells you which validation failed. 

- Trimmed leading whitespace making the stacktrace harder to read
- Added message to top of stacktrace making it more understandable



```diff
+ Assert.True() Failure
+ Expected: True
+ Actual:   False
+ at NeovimDebugProject.IntegrationTests.Services.MathServiceTests.Add_ShouldHandleLargeNumbers() in C:\Users\Gustav\repo\NeovimDebugProject\src\NeovimDebugProject.IntegrationTests\Services\MathServiceTests.cs:line 17
+ at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+ at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
-    at NeovimDebugProject.IntegrationTests.Services.MathServiceTests.Add_ShouldHandleLargeNumbers() in C:\Users\Gustav\repo\NeovimDebugProject\src\NeovimDebugProject.IntegrationTests\Services\MathServiceTests.cs:line 17
-    at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
-    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```


![image](https://github.com/user-attachments/assets/2d0512f3-f807-4fbd-bf64-a57eb3c06b18)


