### PR TITLE
fix(testrunner): stacktrace undefined using Expecto

### DIFF
--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -31,7 +31,12 @@ local function parse_status(result, test_line, options)
     test_line.icon = options.icons.passed
   elseif result.outcome == "Failed" then
     test_line.icon = options.icons.failed
-    test_line.expand = vim.split(result.message .. "\n" .. result.stackTrace:gsub("^%s+", ""):gsub("\n%s+", "\n"), "\n")
+    if result.message or result.stackTrace then
+      test_line.expand = vim.split(
+        (result.message or "") ..
+        "\n" ..
+        (result.stackTrace or ""):gsub("^%s+", ""):gsub("\n%s+", "\n"), "\n")
+    end
   elseif result.outcome == "NotExecuted" then
     test_line.icon = options.icons.skipped
   else


### PR DESCRIPTION
When using Expecto F# test framework a test will produce an xml file similiar to the other test frameworks. If the test fails there will be noe stacktrace node, rather it is included in the message
The code used to assume that the stacktrace property will always be populated if the test failed. This is not the case

## Expecto
```xml
      <Output>
        <ErrorInfo>
          <Message>
These should equal. String does not match at position 4. Expected char: 'e', but got 'ë'.
expected: abcdef
  actual: abcdëf
   at Tests.tests@30-6.Invoke(Unit _arg7) in NeovimDebugProject.Expecto\Sample.fs:line 31&#xD;
   at Expecto.Impl.execTestAsync@569-1.Invoke(Unit unitVar)&#xD;
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 508&#xD;
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112</Message>
        </ErrorInfo>
      </Output>
```

## XUnit
```xml
      <Output>
        <ErrorInfo>
          <Message>Assert.True() Failure&#xD;
Expected: True&#xD;
Actual:   False</Message>
          <StackTrace>   at NeovimDebugProject.IntegrationTests.Services.MathServiceTests.Add_ShouldHandleLargeNumbers() in NeovimDebugProject.IntegrationTests\Services\MathServiceTests.cs:line 17&#xD;
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)&#xD;
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</StackTrace>
        </ErrorInfo>
      </Output>

```