### PR TITLE
feat:🎁 passing any dotnet argument to `Dotnet run|test|build`

### DIFF
--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -33,9 +33,10 @@ local function passthrough_dotnet_cli_args_handler(arguments)
   elseif loweredArgument == "--no-restore" then
     return string.format("--no-restore %s",
       passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments) or ""))
-  else
-    vim.notify("Unknown argument to dotnet build " .. loweredArgument, vim.log.levels.WARN)
   end
+
+  return string.format("%s %s", loweredArgument,
+    passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments)))
 end
 
 local actions = require("easy-dotnet.actions")

--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -17,22 +17,16 @@ local function passthrough_dotnet_cli_args_handler(arguments)
   end
 
   local loweredArgument = arguments[1]:lower()
+  -- Shorthand dotnet build release -> dotnet build -c release
   if loweredArgument == "release" then
     return string.format("-c release %s",
       passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments) or ""))
   elseif loweredArgument == "debug" then
     return string.format("-c debug %s",
       passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments) or ""))
-  elseif loweredArgument == "-c" then
-    local flag = string.format("-c %s", #arguments >= 2 and arguments[2] or "")
-    return string.format("%s %s", flag,
+  elseif loweredArgument == "-c" or loweredArgument == "--configuration" then
+    return string.format("%s %s %s", loweredArgument, (#arguments >= 2 and arguments[2] or ""),
       passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 3, #arguments) or ""))
-  elseif loweredArgument == "--no-build" then
-    return string.format("--no-build %s",
-      passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments) or ""))
-  elseif loweredArgument == "--no-restore" then
-    return string.format("--no-restore %s",
-      passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments) or ""))
   end
 
   return string.format("%s %s", loweredArgument,

--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -33,6 +33,13 @@ local function passthrough_dotnet_cli_args_handler(arguments)
     passthrough_dotnet_cli_args_handler(vim.list_slice(arguments, 2, #arguments)))
 end
 
+---@param args string | string[] | nil
+---@return string
+local function stringify_args(args)
+  ---@type string
+  return type(args) == "table" and table.concat(args, " ") or args or ""
+end
+
 local actions = require("easy-dotnet.actions")
 
 ---This entire object is exposed, any change to this will possibly be a breaking change, tread carefully
@@ -96,8 +103,7 @@ M.test = {
 
 M.restore = {
   handle = function(args, options)
-    local string_args = type(args) == "table" and table.concat(args, " ") or args or ""
-    actions.restore(options.terminal, string_args)
+    actions.restore(options.terminal, stringify_args(args))
   end,
   passthrough = true
 }
@@ -181,8 +187,7 @@ M.outdated = {
 
 M.clean = {
   handle = function(args)
-    local string_args = type(args) == "table" and table.concat(args, " ") or args or ""
-    require("easy-dotnet.actions.clean").clean_solution(string_args)
+    require("easy-dotnet.actions.clean").clean_solution(stringify_args(args))
   end,
   passthrough = true
 }


### PR DESCRIPTION
Previously I was careful with allowing additional args to `dotnet build|run|test` but given my new setup with commands it wont be an issue. Opening up the implementation so that any argument can be passed through. Subcommands will always take precedence over args