### PR TITLE
fix: dont check status of coroutine if nil

### DIFF
--- a/lua/easy-dotnet/picker.lua
+++ b/lua/easy-dotnet/picker.lua
@@ -111,8 +111,10 @@ M.pick_sync = function(bufnr, options, title, autopick)
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
-    if coroutine.status(co) ~= "running" then
-      coroutine.resume(co)
+    if co then
+      if coroutine.status(co) ~= "running" then
+        coroutine.resume(co)
+      end
     end
   end, title or "", autopick)
   if not selected then


### PR DESCRIPTION
Encountered a bug with the coroutine where coroutine.status(nil) is not a valid call.

Therefore this adds a simple null check before to ensure that the coroutine.status function is not called with a nil value