### PR TITLE
feat:🎁 .net framework support

### DIFF
--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -165,9 +165,6 @@ M.is_test_project = function(project_file_path)
 end
 
 M.is_web_project = function(project_file_path)
-  -- UseIISExpress
-  -- Use64BitIISExpress
-  -- <IISExpress....
   return type(extract_from_project(project_file_path, '<Project%s+Sdk="Microsoft.NET.Sdk.Web"')) == "string"
     or type(extract_from_project(project_file_path, "<ProjectTypeGuids>.*{fae04ec0-301f-11d3-bf4b-00c04f79efbc}.*</ProjectTypeGuids>")) == "string"
 end

--- a/lua/easy-dotnet/parsers/csproj-parse.lua
+++ b/lua/easy-dotnet/parsers/csproj-parse.lua
@@ -132,7 +132,7 @@ M.get_project_from_project_file = function(project_file_path)
 end
 
 M.extract_version = function(project_file_path)
-  local version = extract_from_project(project_file_path, "<TargetFramework>net(.-)</TargetFramework>")
+  local version = extract_from_project(project_file_path, "<TargetFramework>net(.-)</TargetFramework>") or extract_from_project(project_file_path, "<TargetFrameworkVersion>v(.-)</TargetFrameworkVersion>")
   if version == false then return nil end
   return version
 end
@@ -164,7 +164,13 @@ M.is_test_project = function(project_file_path)
   return false
 end
 
-M.is_web_project = function(project_file_path) return type(extract_from_project(project_file_path, '<Project%s+Sdk="Microsoft.NET.Sdk.Web"')) == "string" end
+M.is_web_project = function(project_file_path)
+  -- UseIISExpress
+  -- Use64BitIISExpress
+  -- <IISExpress....
+  return type(extract_from_project(project_file_path, '<Project%s+Sdk="Microsoft.NET.Sdk.Web"')) == "string"
+    or type(extract_from_project(project_file_path, "<ProjectTypeGuids>.*{fae04ec0-301f-11d3-bf4b-00c04f79efbc}.*</ProjectTypeGuids>")) == "string"
+end
 
 M.find_csproj_file = function()
   local file = require("plenary.scandir").scan_dir({ "." }, { search_pattern = "%.csproj$", depth = 3 })


### PR DESCRIPTION
When parsing a .csproj file we look for certain lua patterns to extract metadata. These need to support .net framework aswell

- [x] Version
- [x] is_web_project


**EDIT**

I started on this but now realize that it doesnt make sense to support .net framework as of now. The `dotnet cli` has really poor support for .net framework so the scope for making it work would be pretty big