### PR TITLE
Add blink.cmp support for "latest" snippet

### DIFF
--- a/lua/easy-dotnet/completion/blink.lua
+++ b/lua/easy-dotnet/completion/blink.lua
@@ -51,7 +51,11 @@ function M:get_completions(ctx, callback)
     vim.fn.jobstart(string.format("%s | jq '.searchResult[].packages[].version'", command), {
       stdout_buffered = true,
       on_stdout = function(_, data)
+        local index = 0
+        local latest = nil
+        local last_index = #data - 1
         local items = polyfills.tbl_map(function(i)
+          index = index + 1
           local label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', "")
           local cmp_item = {
             label = label,
@@ -60,8 +64,18 @@ function M:get_completions(ctx, callback)
             dup = 0,
             kind = 11,
           }
+          if index == last_index then latest = cmp_item.label end
           return cmp_item
         end, data)
+        if latest then
+          table.insert(items, {
+            label = "latest",
+            insertText = latest,
+            documentation = "auto insert the latest version available",
+            kind = 15,
+            preselect = true,
+          })
+        end
         transformed_callback(items)
       end,
     })

--- a/lua/easy-dotnet/completion/blink.lua
+++ b/lua/easy-dotnet/completion/blink.lua
@@ -71,7 +71,7 @@ function M:get_completions(ctx, callback)
           table.insert(items, {
             label = "latest",
             insertText = latest,
-            documentation = "auto insert the latest version available",
+            documentation = "Insert latest version available: " .. latest,
             kind = 15,
             preselect = true,
           })


### PR DESCRIPTION
Hey,
Thanks for adding support for blink.cmp too.
I just wanted to port the "latest" snippet here too.
it works exactly the same as with nvim-cmp.
Cheers