### PR TITLE
fix(project-view): keymaps being set globally instead of locally

### DIFF
--- a/lua/easy-dotnet/project-view/render.lua
+++ b/lua/easy-dotnet/project-view/render.lua
@@ -338,7 +338,7 @@ local function print_lines()
             end
           end
         end
-      end, { silent = true, noremap = true })
+      end, { silent = true, noremap = true, buffer = M.buf })
     end
   end
 


### PR DESCRIPTION
Simple fix for a bug that caused the `project-view` window keymaps to be set globally instead of to the `project-view` buffer.