### PR TITLE
fix: testrunner invalid buffer

### DIFF
--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -293,7 +293,7 @@ local function open_runner(options, sdk_path)
     return
   end
 
-  local is_reused = win.buf ~= nil and win.tree and win.tree.solution_file_path == solutionFilePath
+  local is_reused = win.buf ~= nil and vim.api.nvim_buf_is_valid(win.buf) and win.tree and win.tree.solution_file_path == solutionFilePath
 
   win.buf_name = "Test manager"
   win.filetype = "easy-dotnet"


### PR DESCRIPTION
Reopening testrunner buffer fails sometimes giving errror: 
```
Coroutine failed: .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/runner.lua:356: vim/keymap.lua:0: Invalid buffer id: 127
```
No idea why. An extra check if the last used testrunner buffer is still valid should fix the problem. 
