### PR TITLE
fix: add BufNewFile to auto_bootstrap_namespace autocmd

### DIFF
--- a/lua/easy-dotnet/cs-mappings.lua
+++ b/lua/easy-dotnet/cs-mappings.lua
@@ -111,7 +111,7 @@ end
 
 ---@param mode BootstrapNamespaceMode
 M.auto_bootstrap_namespace = function(mode)
-  vim.api.nvim_create_autocmd({ "BufReadPost" }, {
+  vim.api.nvim_create_autocmd({ "BufReadPost", "BufNewFile" }, {
     pattern = "*.cs",
     callback = function()
       local bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
Currently, if you add a file from netrw (press %, type the name, open it), the automatic namespace bootstrapping doesn't happen. To solve this, I added BufNewFile to the autocmd to make it trigger when opening completely new files.