### PR TITLE
fix(completion): 'failed to get completions' with blink.cmp

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,4 @@
 max_line_length = 220
 std = "luajit"
 globals = { "vim" }
+ignore = { "212/self" } -- See PR #300

--- a/lua/easy-dotnet/completion/blink.lua
+++ b/lua/easy-dotnet/completion/blink.lua
@@ -5,15 +5,15 @@ local M = {}
 
 function M.new() return setmetatable({}, { __index = M }) end
 
-function M.get_trigger_characters() return { 'Include="', "Include='", "Version='", 'Version="' } end
+function M:get_trigger_characters() return { 'Include="', "Include='", "Version='", 'Version="' } end
 
-function M.enabled()
+function M:enabled()
   local filetypes = { "csproj", "fsproj", "xml" }
   local is_enabled = vim.tbl_contains(filetypes, vim.bo.filetype)
   return is_enabled
 end
 
-function M.get_completions(ctx, callback)
+function M:get_completions(ctx, callback)
   local transformed_callback = function(items)
     callback({
       context = ctx,


### PR DESCRIPTION
Fix for an error that prints `failed to get completions with error: ...zy/easy-dotnet.nvim/lua/easy-dotnet/completion/blink.lua:18: attempt to call upvalue 'callback' (a table value)` when entering insert mode on an xml, csproj or fsproj file. This error makes blink completion stop working.

This error was introduced in commit f23ca5f due to luacheck marking the methods with warning 212 `unused argument self` and fixing the warning by converting the methods to functions. This could be fixed by either using comments to ignore the lines in the file:

```lua
-- luacheck: push no unused args
function M:get_completions(ctx, callback) ... end
-- ...
-- luacheck: pop
```

or by ignoring it globally for the `self` argument in `.luacheckrc`:

```lua
ignore = { "212/self" }
```

With the latter approach it might even be beneficial to apply it to all arguments, not just `self`, just in case the unused argument is used by the users or by another library and gets deleted, causing the same issue.

How should we proceed?