### PR TITLE
feat: improve healthcheck

### DIFF
--- a/lua/easy-dotnet/health.lua
+++ b/lua/easy-dotnet/health.lua
@@ -81,15 +81,12 @@ local function check_cmp()
   vim.health.warn("cmp source not configured", { "https://github.com/GustavEikaas/easy-dotnet.nvim?tab=readme-ov-file#package-autocomplete" })
 end
 
-
 local function os_info()
   local platform = vim.loop.os_uname()
   local sysname = platform.sysname
   local release = platform.release
 
-  if release:lower():match("arch") then
-    release = release .. " btw"
-  end
+  if release:lower():match("arch") then release = release .. " btw" end
 
   vim.health.info(string.format("%s (%s)", sysname, release))
 end
@@ -164,13 +161,13 @@ M.check = function()
   end
 
   local sdk_path_time, path = measure_function(config.get_sdk_path)
-  vim.health.ok('sdk_path: '..path)
+  vim.health.ok("sdk_path: " .. path)
   if sdk_path_time > 1 then
     vim.health.warn(string.format("options.get_sdk_path took %d seconds", sdk_path_time), "You should add get_sdk_path to your options for a performance improvement🚀. Check readme")
   end
   check_cmp()
   vim.health.start("User config")
-  vim.health.info(vim.inspect(require('easy-dotnet.options').orig_config))
+  vim.health.info(vim.inspect(require("easy-dotnet.options").orig_config))
 end
 
 return M

--- a/lua/easy-dotnet/health.lua
+++ b/lua/easy-dotnet/health.lua
@@ -121,10 +121,16 @@ local function print_nvim_version()
   vim.health.info(version_str)
 end
 
+local function get_shell_info()
+  local shell = vim.o.shell
+  vim.health.info("Shell: " .. shell)
+end
+
 M.check = function()
   vim.health.start("General information")
   os_info()
   print_nvim_version()
+  get_shell_info()
   vim.health.start("Dotnet information")
   print_dotnet_info()
   vim.health.start("easy-dotnet CLI dependencies")

--- a/lua/easy-dotnet/health.lua
+++ b/lua/easy-dotnet/health.lua
@@ -35,10 +35,10 @@ end
 
 local function measure_function(cb)
   local start_time = os.clock()
-  cb()
+  local res = cb()
   local end_time = os.clock()
   local elapsed_time = end_time - start_time
-  return elapsed_time
+  return elapsed_time, res
 end
 
 local function check_coreclr_configured()
@@ -81,7 +81,52 @@ local function check_cmp()
   vim.health.warn("cmp source not configured", { "https://github.com/GustavEikaas/easy-dotnet.nvim?tab=readme-ov-file#package-autocomplete" })
 end
 
+
+local function os_info()
+  local platform = vim.loop.os_uname()
+  local sysname = platform.sysname
+  local release = platform.release
+
+  if release:lower():match("arch") then
+    release = release .. " btw"
+  end
+
+  vim.health.info(string.format("%s (%s)", sysname, release))
+end
+
+local function print_dotnet_info()
+  local version = vim.fn.system("dotnet --version"):gsub("\n", "")
+  local sdks = vim.fn.systemlist("dotnet --list-sdks")
+
+  if version == "" then
+    vim.health.warn("dotnet is not installed or not in PATH")
+    return
+  end
+
+  vim.health.info("dotnet version: " .. version)
+
+  if #sdks == 0 then
+    vim.health.warn("No .NET SDKs found")
+  else
+    vim.health.info("Installed SDKs:")
+    for _, sdk in ipairs(sdks) do
+      vim.health.info("  " .. sdk)
+    end
+  end
+end
+
+local function print_nvim_version()
+  local v = vim.version()
+  local version_str = string.format("Neovim version: %d.%d.%d", v.major, v.minor, v.patch)
+  vim.health.info(version_str)
+end
+
 M.check = function()
+  vim.health.start("General information")
+  os_info()
+  print_nvim_version()
+  vim.health.start("Dotnet information")
+  print_dotnet_info()
   vim.health.start("easy-dotnet CLI dependencies")
   ensure_dep_installed({ "dotnet", "-h" })
   ensure_dep_installed({ "jq" })
@@ -112,11 +157,14 @@ M.check = function()
     ensure_nvim_dep_installed("snacks", { "This is selected in your config but is not installed", "A fallback will be used instead", "https://github.com/folke/snacks.nvim" }, true)
   end
 
-  local sdk_path_time = measure_function(config.get_sdk_path)
+  local sdk_path_time, path = measure_function(config.get_sdk_path)
+  vim.health.ok('sdk_path: '..path)
   if sdk_path_time > 1 then
     vim.health.warn(string.format("options.get_sdk_path took %d seconds", sdk_path_time), "You should add get_sdk_path to your options for a performance improvement🚀. Check readme")
   end
   check_cmp()
+  vim.health.start("User config")
+  vim.health.info(vim.inspect(require('easy-dotnet.options').orig_config))
 end
 
 return M

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -153,7 +153,10 @@ local function handle_auto_bootstrap_namespace(a)
   } end
 end
 
+M.orig_config = nil
+
 M.set_options = function(a)
+  M.orig_config = a
   a = a or {}
   handle_auto_bootstrap_namespace(a)
   M.options = merge_tables(M.options, a)


### PR DESCRIPTION
I have gotten more why isnt this working issues lately and I find myself requesting the same info every time.Extending the healthcheck will hopefully make it easier to check the 'usual suspects' without having to ask every user for it

@bosvik thoughts? Something useful I might have missed?


This will add following
- Neovim version
- OS platform info
- Dotnet version
- Dotnet sdks
- Sdk path 
- User plugin config (before merge)
- Shell info