### PR TITLE
Use dotnet sln instead of dotnet solution since the later does not exist

### DIFF
--- a/lua/easy-dotnet/dotnet_cli.lua
+++ b/lua/easy-dotnet/dotnet_cli.lua
@@ -18,6 +18,6 @@ function M.package_search(query, is_json, exact, take)
   return string.format("dotnet package search %s %s %s %s", query, take_query, json_query, exact_query)
 end
 
-function M.list_packages(sln_file_path) return string.format("dotnet solution %s list", sln_file_path) end
+function M.list_packages(sln_file_path) return string.format("dotnet sln %s list", sln_file_path) end
 
 return M


### PR DESCRIPTION
`solution` is not a verb for the dotnet cli. Using sln so it can actually find projects in a solution.