### PR TITLE
Add numbering to picker and use it for debug projects list

### DIFF
--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -29,7 +29,7 @@ local function pick_project(use_default)
     logger.error(error_messages.no_runnable_projects_found)
     return
   end
-  local project = picker.pick_sync(nil, projects, "Debug project")
+  local project = picker.pick_sync(nil, projects, "Debug project", false, true)
   if not project then
     logger.error("No project selected")
     return

--- a/lua/easy-dotnet/debugger.lua
+++ b/lua/easy-dotnet/debugger.lua
@@ -29,7 +29,7 @@ local function pick_project(use_default)
     logger.error(error_messages.no_runnable_projects_found)
     return
   end
-  local project = picker.pick_sync(nil, projects, "Debug project", false, true)
+  local project = picker.pick_sync(nil, projects, "Debug project")
   if not project then
     logger.error("No project selected")
     return

--- a/lua/easy-dotnet/picker/_base.lua
+++ b/lua/easy-dotnet/picker/_base.lua
@@ -89,7 +89,7 @@ M.preview_picker = function(_, options, on_select_cb, title, _)
   end)
 end
 
-M.picker = function(_, options, on_select_cb, title, autopick)
+M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
   -- Auto pick if only one option present
@@ -99,8 +99,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local items = {}
-  for _, option in ipairs(options) do
-    table.insert(items, option.display)
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(items, display_text)
   end
 
   vim.ui.select(items, { prompt = title }, function(choice)
@@ -119,14 +121,16 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean | nil
+---@param apply_numeration boolean | nil
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_base.lua
+++ b/lua/easy-dotnet/picker/_base.lua
@@ -90,7 +90,6 @@ M.preview_picker = function(_, options, on_select_cb, title, _)
 end
 
 M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
-  if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
   -- Auto pick if only one option present
   if #options == 1 and autopick == true then
@@ -121,8 +120,8 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
----@param autopick boolean | nil
----@param apply_numeration boolean | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
 M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()

--- a/lua/easy-dotnet/picker/_fzf.lua
+++ b/lua/easy-dotnet/picker/_fzf.lua
@@ -105,7 +105,7 @@ M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, re
   })
 end
 
-M.picker = function(_, options, on_select_cb, title, autopick)
+M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
@@ -115,8 +115,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local fzf_options = {}
-  for _, option in ipairs(options) do
-    table.insert(fzf_options, option.display)
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(fzf_options, display_text)
   end
 
   require("fzf-lua").fzf_exec(fzf_options, {
@@ -142,13 +144,13 @@ end
 ---@param options table<T>
 ---@param title string | nil
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_fzf.lua
+++ b/lua/easy-dotnet/picker/_fzf.lua
@@ -106,7 +106,6 @@ M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, re
 end
 
 M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
-  if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   if #options == 1 and autopick == true then
@@ -143,6 +142,8 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
 M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()

--- a/lua/easy-dotnet/picker/_snacks.lua
+++ b/lua/easy-dotnet/picker/_snacks.lua
@@ -119,7 +119,7 @@ end
 ---@param on_select_cb function
 ---@param title string | nil
 ---@param autopick boolean | nil
-M.picker = function(_, options, on_select_cb, title, autopick)
+M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
@@ -130,8 +130,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local picker_items = {}
-  for _, option in ipairs(options) do
-    table.insert(picker_items, { text = option.display, option = option })
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(picker_items, { text = display_text, option = option })
   end
 
   require("snacks").picker.pick(nil, {
@@ -150,15 +152,17 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean | nil
+---@param apply_numeration boolean | nil
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
 
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
 
   if not selected then coroutine.yield() end
 

--- a/lua/easy-dotnet/picker/_snacks.lua
+++ b/lua/easy-dotnet/picker/_snacks.lua
@@ -74,13 +74,12 @@ local function get_preview_text(option, get_secret_path, read_file)
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
 ---@param get_secret_path function
 ---@param read_content function
-M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, read_content)
+M.preview_picker = function(options, on_select_cb, title, get_secret_path, read_content)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -114,13 +113,12 @@ M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, re
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
----@param autopick boolean | nil
-M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
-  if autopick == nil then autopick = true end
+---@param autopick boolean
+---@param apply_numeration boolean
+M.picker = function(options, on_select_cb, title, autopick, apply_numeration)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -149,17 +147,16 @@ M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
----@param autopick boolean | nil
----@param apply_numeration boolean | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
+M.pick_sync = function(options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
 
-  M.picker(bufnr, options, function(i)
+  M.picker(options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
   end, title or "", autopick, apply_numeration)

--- a/lua/easy-dotnet/picker/_telescope.lua
+++ b/lua/easy-dotnet/picker/_telescope.lua
@@ -113,7 +113,8 @@ end
 ---@param on_select_cb function
 ---@param title string | nil
 ---@param autopick boolean | nil
-M.picker = function(bufnr, options, on_select_cb, title, autopick)
+---@param apply_numeration boolean | nil
+M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
@@ -122,15 +123,31 @@ M.picker = function(bufnr, options, on_select_cb, title, autopick)
     on_select_cb(options[1])
     return
   end
+
+  local options_for_finder = {}
+  for i, option in ipairs(options) do
+    local display_text
+    if apply_numeration then
+      display_text = i .. ". " .. option.display
+    else
+      display_text = option.display
+    end
+
+    table.insert(options_for_finder, {
+      display_text,
+      option,
+    })
+  end
+
   local picker = require("telescope.pickers").new(bufnr, {
     prompt_title = title,
     finder = require("telescope.finders").new_table({
-      results = options,
+      results = options_for_finder,
       entry_maker = function(entry)
         return {
-          display = entry.display,
-          value = entry,
-          ordinal = entry.display,
+          display = entry.display_text,
+          value = entry.option,
+          ordinal = entry.display_text,
         }
       end,
     }),
@@ -157,14 +174,16 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean | nil
+---@param apply_numeration boolean | nil
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_telescope.lua
+++ b/lua/easy-dotnet/picker/_telescope.lua
@@ -112,10 +112,9 @@ end
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
----@param autopick boolean | nil
----@param apply_numeration boolean | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numeration)
-  if autopick == nil then autopick = true end
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -174,8 +173,8 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
----@param autopick boolean | nil
----@param apply_numeration boolean | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
 M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()

--- a/lua/easy-dotnet/picker/init.lua
+++ b/lua/easy-dotnet/picker/init.lua
@@ -93,17 +93,17 @@ M.picker = function(bufnr, options, on_select_cb, title, autopick)
   end
 end
 
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local active_picker = get_active_picker()
 
   if active_picker == "fzf" then
-    return require("easy-dotnet.picker._fzf").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._fzf").pick_sync(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "telescope" then
-    return require("easy-dotnet.picker._telescope").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._telescope").pick_sync(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._snacks").pick_sync(bufnr, options, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick, apply_numeration)
   end
 end
 

--- a/lua/easy-dotnet/picker/init.lua
+++ b/lua/easy-dotnet/picker/init.lua
@@ -73,27 +73,33 @@ M.preview_picker = function(bufnr, options, on_select_cb, title, previewer, get_
   elseif active_picker == "telescope" then
     return require("easy-dotnet.picker._telescope").preview_picker(bufnr, options, on_select_cb, title, previewer)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").preview_picker(bufnr, options, on_select_cb, title, get_secret_path, readFile)
+    return require("easy-dotnet.picker._snacks").preview_picker(options, on_select_cb, title, get_secret_path, readFile)
   else
     return require("easy-dotnet.picker._base").preview_picker(bufnr, options, on_select_cb, title, previewer)
   end
 end
 
-M.picker = function(bufnr, options, on_select_cb, title, autopick)
+M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numeration)
+  if autopick == nil then autopick = true end
+  if apply_numeration == nil then apply_numeration = true end
+
   local active_picker = get_active_picker()
 
   if active_picker == "fzf" then
-    return require("easy-dotnet.picker._fzf").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._fzf").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   elseif active_picker == "telescope" then
-    return require("easy-dotnet.picker._telescope").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._telescope").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._snacks").picker(options, on_select_cb, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   end
 end
 
 M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
+  if autopick == nil then autopick = true end
+  if apply_numeration == nil then apply_numeration = true end
+
   local active_picker = get_active_picker()
 
   if active_picker == "fzf" then
@@ -101,7 +107,7 @@ M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "telescope" then
     return require("easy-dotnet.picker._telescope").pick_sync(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").pick_sync(bufnr, options, title, autopick, apply_numeration)
+    return require("easy-dotnet.picker._snacks").pick_sync(options, title, autopick, apply_numeration)
   else
     return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick, apply_numeration)
   end


### PR DESCRIPTION
This feature makes it easier to quickly select item from the list.
I used it for the debug projects list:

![image](https://github.com/user-attachments/assets/43bfc370-2c9b-4f4e-90c1-b5442490c9af)


