### PR TITLE
Readd numeration for pickers

### DIFF
--- a/lua/easy-dotnet/picker/_base.lua
+++ b/lua/easy-dotnet/picker/_base.lua
@@ -89,7 +89,7 @@ M.preview_picker = function(_, options, on_select_cb, title, _)
   end)
 end
 
-M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
+M.picker = function(_, options, on_select_cb, title, autopick)
   if #options == 0 then error("No options provided, minimum 1 is required") end
   -- Auto pick if only one option present
   if #options == 1 and autopick == true then
@@ -98,10 +98,8 @@ M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   end
 
   local items = {}
-  for index, option in ipairs(options) do
-    local display_text = option.display
-    if apply_numeration then display_text = index .. ". " .. option.display end
-    table.insert(items, display_text)
+  for _, option in ipairs(options) do
+    table.insert(items, option.display)
   end
 
   vim.ui.select(items, { prompt = title }, function(choice)
@@ -121,15 +119,14 @@ end
 ---@param options table<T>
 ---@param title string | nil
 ---@param autopick boolean
----@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
+M.pick_sync = function(bufnr, options, title, autopick)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick, apply_numeration)
+  end, title or "", autopick)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_base.lua
+++ b/lua/easy-dotnet/picker/_base.lua
@@ -89,8 +89,7 @@ M.preview_picker = function(_, options, on_select_cb, title, _)
   end)
 end
 
-M.picker = function(_, options, on_select_cb, title, autopick)
-  if autopick == nil then autopick = true end
+M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   if #options == 0 then error("No options provided, minimum 1 is required") end
   -- Auto pick if only one option present
   if #options == 1 and autopick == true then
@@ -99,8 +98,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local items = {}
-  for _, option in ipairs(options) do
-    table.insert(items, option.display)
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(items, display_text)
   end
 
   vim.ui.select(items, { prompt = title }, function(choice)
@@ -119,14 +120,16 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_fzf.lua
+++ b/lua/easy-dotnet/picker/_fzf.lua
@@ -105,8 +105,7 @@ M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, re
   })
 end
 
-M.picker = function(_, options, on_select_cb, title, autopick)
-  if autopick == nil then autopick = true end
+M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   if #options == 1 and autopick == true then
@@ -115,8 +114,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local fzf_options = {}
-  for _, option in ipairs(options) do
-    table.insert(fzf_options, option.display)
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(fzf_options, display_text)
   end
 
   require("fzf-lua").fzf_exec(fzf_options, {
@@ -141,14 +142,16 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/_fzf.lua
+++ b/lua/easy-dotnet/picker/_fzf.lua
@@ -126,9 +126,9 @@ M.picker = function(_, options, on_select_cb, title, autopick, apply_numeration)
     actions = {
       ["default"] = function(selected)
         local selected_value = nil
-        for _, option in ipairs(options) do
-          if option.display == selected[1] then
-            selected_value = option
+        for i, display_text in ipairs(fzf_options) do
+          if display_text == selected[1] then
+            selected_value = options[i]
             break
           end
         end

--- a/lua/easy-dotnet/picker/_snacks.lua
+++ b/lua/easy-dotnet/picker/_snacks.lua
@@ -74,13 +74,12 @@ local function get_preview_text(option, get_secret_path, read_file)
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
 ---@param get_secret_path function
 ---@param read_content function
-M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, read_content)
+M.preview_picker = function(options, on_select_cb, title, get_secret_path, read_content)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -114,13 +113,12 @@ M.preview_picker = function(_, options, on_select_cb, title, get_secret_path, re
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
----@param autopick boolean | nil
-M.picker = function(_, options, on_select_cb, title, autopick)
-  if autopick == nil then autopick = true end
+---@param autopick boolean
+---@param apply_numeration boolean
+M.picker = function(options, on_select_cb, title, autopick, apply_numeration)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -130,8 +128,10 @@ M.picker = function(_, options, on_select_cb, title, autopick)
   end
 
   local picker_items = {}
-  for _, option in ipairs(options) do
-    table.insert(picker_items, { text = option.display, option = option })
+  for index, option in ipairs(options) do
+    local display_text = option.display
+    if apply_numeration then display_text = index .. ". " .. option.display end
+    table.insert(picker_items, { text = display_text, option = option })
   end
 
   require("snacks").picker.pick(nil, {
@@ -147,18 +147,19 @@ M.picker = function(_, options, on_select_cb, title, autopick)
 end
 
 ---@generic T
----@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
 
-  M.picker(bufnr, options, function(i)
+  M.picker(options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
 
   if not selected then coroutine.yield() end
 

--- a/lua/easy-dotnet/picker/_telescope.lua
+++ b/lua/easy-dotnet/picker/_telescope.lua
@@ -133,10 +133,13 @@ M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numerat
     end
 
     table.insert(options_for_finder, {
-      display_text,
-      option,
+      display_text = display_text,
+      option = option,
     })
   end
+
+  require("snacks").debug(options)
+  -- require("snacks").debug(options_for_finder)
 
   local picker = require("telescope.pickers").new(bufnr, {
     prompt_title = title,

--- a/lua/easy-dotnet/picker/_telescope.lua
+++ b/lua/easy-dotnet/picker/_telescope.lua
@@ -112,9 +112,9 @@ end
 ---@param options table<T>
 ---@param on_select_cb function
 ---@param title string | nil
----@param autopick boolean | nil
-M.picker = function(bufnr, options, on_select_cb, title, autopick)
-  if autopick == nil then autopick = true end
+---@param autopick boolean
+---@param apply_numeration boolean
+M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   if #options == 0 then error("No options provided, minimum 1 is required") end
 
   -- Auto pick if only one option present
@@ -122,15 +122,31 @@ M.picker = function(bufnr, options, on_select_cb, title, autopick)
     on_select_cb(options[1])
     return
   end
+
+  local options_for_finder = {}
+  for i, option in ipairs(options) do
+    local display_text
+    if apply_numeration then
+      display_text = i .. ". " .. option.display
+    else
+      display_text = option.display
+    end
+
+    table.insert(options_for_finder, {
+      display_text,
+      option,
+    })
+  end
+
   local picker = require("telescope.pickers").new(bufnr, {
     prompt_title = title,
     finder = require("telescope.finders").new_table({
-      results = options,
+      results = options_for_finder,
       entry_maker = function(entry)
         return {
-          display = entry.display,
-          value = entry,
-          ordinal = entry.display,
+          display = entry.display_text,
+          value = entry.option,
+          ordinal = entry.display_text,
         }
       end,
     }),
@@ -157,14 +173,16 @@ end
 ---@param bufnr number | nil
 ---@param options table<T>
 ---@param title string | nil
+---@param autopick boolean
+---@param apply_numeration boolean
 ---@return T
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   local co = coroutine.running()
   local selected = nil
   M.picker(bufnr, options, function(i)
     selected = i
     if coroutine.status(co) ~= "running" then coroutine.resume(co) end
-  end, title or "", autopick)
+  end, title or "", autopick, apply_numeration)
   if not selected then coroutine.yield() end
   return selected
 end

--- a/lua/easy-dotnet/picker/init.lua
+++ b/lua/easy-dotnet/picker/init.lua
@@ -73,37 +73,43 @@ M.preview_picker = function(bufnr, options, on_select_cb, title, previewer, get_
   elseif active_picker == "telescope" then
     return require("easy-dotnet.picker._telescope").preview_picker(bufnr, options, on_select_cb, title, previewer)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").preview_picker(bufnr, options, on_select_cb, title, get_secret_path, readFile)
+    return require("easy-dotnet.picker._snacks").preview_picker(options, on_select_cb, title, get_secret_path, readFile)
   else
     return require("easy-dotnet.picker._base").preview_picker(bufnr, options, on_select_cb, title, previewer)
   end
 end
 
-M.picker = function(bufnr, options, on_select_cb, title, autopick)
+M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numeration)
+  if autopick == nil then autopick = true end
+  if apply_numeration == nil then apply_numeration = true end
+
   local active_picker = get_active_picker()
 
   if active_picker == "fzf" then
-    return require("easy-dotnet.picker._fzf").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._fzf").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   elseif active_picker == "telescope" then
-    return require("easy-dotnet.picker._telescope").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._telescope").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._snacks").picker(options, on_select_cb, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick)
+    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
   end
 end
 
-M.pick_sync = function(bufnr, options, title, autopick)
+M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
+  if autopick == nil then autopick = true end
+  if apply_numeration == nil then apply_numeration = true end
+
   local active_picker = get_active_picker()
 
   if active_picker == "fzf" then
-    return require("easy-dotnet.picker._fzf").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._fzf").pick_sync(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "telescope" then
-    return require("easy-dotnet.picker._telescope").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._telescope").pick_sync(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
-    return require("easy-dotnet.picker._snacks").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._snacks").pick_sync(options, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick)
+    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick, apply_numeration)
   end
 end
 

--- a/lua/easy-dotnet/picker/init.lua
+++ b/lua/easy-dotnet/picker/init.lua
@@ -92,7 +92,7 @@ M.picker = function(bufnr, options, on_select_cb, title, autopick, apply_numerat
   elseif active_picker == "snacks" then
     return require("easy-dotnet.picker._snacks").picker(options, on_select_cb, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick, apply_numeration)
+    return require("easy-dotnet.picker._base").picker(bufnr, options, on_select_cb, title, autopick)
   end
 end
 
@@ -109,7 +109,7 @@ M.pick_sync = function(bufnr, options, title, autopick, apply_numeration)
   elseif active_picker == "snacks" then
     return require("easy-dotnet.picker._snacks").pick_sync(options, title, autopick, apply_numeration)
   else
-    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick, apply_numeration)
+    return require("easy-dotnet.picker._base").pick_sync(bufnr, options, title, autopick)
   end
 end
 


### PR DESCRIPTION
Readds the original commit, and introduces fixes on top of that:

 - telescope works now
 - fzf-lua works now (yeah, this one was borked as well)
 - removes numeration from basic picker, because the outcome is a bit unpredictable. Some implementations of vim.select might add numeration by themselves (as snacks does for example). I think that the "basic" picker is a fallback which really needs just the necessary features.