### PR TITLE
Support solution filters (.slnf)

### DIFF
--- a/lua/easy-dotnet/parsers/sln-parse.lua
+++ b/lua/easy-dotnet/parsers/sln-parse.lua
@@ -157,12 +157,16 @@ end
 function M.get_solutions()
   local sln_files = require("plenary.scandir").scan_dir({ "." }, { search_pattern = "%.sln$", depth = 5 })
   local slnx_files = require("plenary.scandir").scan_dir({ "." }, { search_pattern = "%.slnx$", depth = 5 })
+  local slnf_files = require("plenary.scandir").scan_dir({ "." }, { search_pattern = "%.slnf$", depth = 5 })
 
   local normalized = {}
   for _, value in ipairs(sln_files) do
     table.insert(normalized, value)
   end
   for _, value in ipairs(slnx_files) do
+    table.insert(normalized, value)
+  end
+  for _, value in ipairs(slnf_files) do
     table.insert(normalized, value)
   end
   return normalized


### PR DESCRIPTION
Adds support for [solution filters](https://learn.microsoft.com/en-us/visualstudio/msbuild/solution-filters).
Since [dotnet CLI commands](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-sln) as well as [MSBuild](https://learn.microsoft.com/en-us/visualstudio/msbuild/solution-filters) already support solution filters, letting '.slnf' files to be discovered by the plugin during directory scan seems to be sufficient.

I have tested the same to be working on a Windows 11 machine.