### PR TITLE
fix: resolve testrunner pipe path on macos

### DIFF
--- a/lua/easy-dotnet/extensions.lua
+++ b/lua/easy-dotnet/extensions.lua
@@ -5,4 +5,9 @@ E.isWindows = function()
   return platform == "Windows_NT"
 end
 
+E.isDarwin = function()
+  local platform = vim.loop.os_uname().sysname
+  return platform == "Darwin"
+end
+
 return E

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -113,7 +113,7 @@ local function start_server(solution_file_path)
             if extensions.isWindows() then
               full_pipe_path = [[\\.\pipe\]] .. M._server.pipe_name
             elseif extensions.isDarwin() then
-              full_pipe_path = os.getenv("TMPDIR") .. "CoreFxPipe" .. M._server.pipe_name
+              full_pipe_path = os.getenv("TMPDIR") .. "CoreFxPipe_" .. M._server.pipe_name
             else
               full_pipe_path = "/tmp/CoreFxPipe_" .. M._server.pipe_name
             end

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -109,9 +109,14 @@ local function start_server(solution_file_path)
             local pipename = line:sub(#server_ready_prefix + 1)
             M._server.pipe_name = vim.trim(pipename)
             M._server.client = require("easy-dotnet.test-runner.rpc-client")
-            local full_pipe_path = extensions.isWindows() and [[\\.\pipe\]] .. M._server.pipe_name
-              or "/tmp/CoreFxPipe_" .. M._server.pipe_name
-              or os.getenv("TMPDIR") .. "CoreFxPipe" .. M._server.pipe_name
+            local full_pipe_path
+            if extensions.isWindows() then
+              full_pipe_path = [[\\.\pipe\]] .. M._server.pipe_name
+            elseif extensions.isDarwin() then
+              full_pipe_path = os.getenv("TMPDIR") .. "CoreFxPipe" .. M._server.pipe_name
+            else
+              full_pipe_path = "/tmp/CoreFxPipe_" .. M._server.pipe_name
+            end
 
             is_negotiating = true
             M._server.client.setup({ pipe_path = full_pipe_path, debug = false })

--- a/lua/easy-dotnet/test-runner/runner.lua
+++ b/lua/easy-dotnet/test-runner/runner.lua
@@ -109,7 +109,9 @@ local function start_server(solution_file_path)
             local pipename = line:sub(#server_ready_prefix + 1)
             M._server.pipe_name = vim.trim(pipename)
             M._server.client = require("easy-dotnet.test-runner.rpc-client")
-            local full_pipe_path = extensions.isWindows() and [[\\.\pipe\]] .. M._server.pipe_name or "/tmp/CoreFxPipe_" .. M._server.pipe_name
+            local full_pipe_path = extensions.isWindows() and [[\\.\pipe\]] .. M._server.pipe_name
+              or "/tmp/CoreFxPipe_" .. M._server.pipe_name
+              or os.getenv("TMPDIR") .. "CoreFxPipe" .. M._server.pipe_name
 
             is_negotiating = true
             M._server.client.setup({ pipe_path = full_pipe_path, debug = false })


### PR DESCRIPTION
MacOS uses non standard folders as tmp. This fix adds the macOS folder to the path lookup when the server starts