### PR TITLE
feat: background scanning preloading sln projects

### DIFF
--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -157,13 +157,6 @@ local function complete_command(arg_lead, cmdline)
   return matches
 end
 
-local function generate_absolute_path_for_project(path, slnpath)
-  local base = vim.fs.normalize(vim.fn.getcwd())
-  local dir = vim.fs.normalize(vim.fs.dirname(slnpath))
-  local res = vim.fs.normalize(polyfills.fs.joinpath(base, dir, vim.fs.normalize(path)))
-  return res
-end
-
 local function background_scanning(merged_opts)
   if merged_opts.background_scanning then
     --prewarm msbuild properties
@@ -173,33 +166,7 @@ local function background_scanning(merged_opts)
     local path = sln.find_solution_file()
     if not path then return end
 
-    local stdout
-    local stderr
-    local cmd = require("easy-dotnet.dotnet_cli").list_projects(path)
-    vim.fn.jobstart(cmd, {
-      stdout_buffered = true,
-      stderr_buffered = true,
-      on_stdout = function(_, data) stdout = data end,
-      on_stderr = function(_, data) stderr = data end,
-      on_exit = function(_, code)
-        if code == 0 then
-          local function trim(s) return s:match("^%s*(.-)%s*$") end
-          local project_lines = {}
-          for _, line in ipairs(stdout) do
-            local t = trim(line)
-            if t:match("%.csproj$") or t:match("%.fsproj$") then table.insert(project_lines, t) end
-          end
-
-          polyfills.iter(project_lines):each(function(proj_path)
-            local project_file_path = generate_absolute_path_for_project(proj_path, path)
-            require("easy-dotnet.parsers.csproj-parse").preload_msbuild_properties(project_file_path)
-          end)
-        else
-          print("Preloading msbuild properties for " .. path .. " failed")
-          vim.print(stderr)
-        end
-      end,
-    })
+    require("easy-dotnet.parsers.sln-parse").get_projects_from_sln_async(path)
   end
 end
 

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -175,9 +175,7 @@ local function background_scanning(merged_opts)
     --prewarm msbuild properties
     get_solutions_async(function(slns)
       if #slns ~= 1 then return end
-      local path = slns[1]
-
-      require("easy-dotnet.parsers.sln-parse").get_projects_from_sln_async(path)
+      require("easy-dotnet.parsers.sln-parse").get_projects_from_sln_async(slns[1])
     end)
   end
 end

--- a/lua/easy-dotnet/parsers/sln-parse.lua
+++ b/lua/easy-dotnet/parsers/sln-parse.lua
@@ -121,6 +121,77 @@ M.get_projects_and_frameworks_flattened_from_sln = function(solution_file_path, 
   return project_frameworks
 end
 
+---@param project_paths string[]
+---@param solution_file_path string
+---@return DotnetProject[]
+local function get_all_projects_from_paths(project_paths, solution_file_path)
+  return polyfills.tbl_map(function(proj_path)
+    local csproj_parser = require("easy-dotnet.parsers.csproj-parse")
+    local project_file_path = generate_absolute_path_for_project(proj_path, solution_file_path)
+    local project = csproj_parser.get_project_from_project_file(project_file_path)
+    return project
+  end, project_paths)
+end
+
+---Extracts .csproj and .fsproj paths from stdout lines.
+---@param stdout string|string[] Output from dotnet sln list
+---@return string[] project_paths A list of trimmed project paths ending in `.csproj` or `.fsproj`.
+local function get_project_paths_from_stdout(stdout)
+  return polyfills.iter(stdout):map(function(i) return vim.trim(i) end):filter(function(t) return t:match("%.csproj$") or t:match("%.fsproj$") end):totable()
+end
+
+---Parses a .sln file and returns a list of DotnetProject objects.
+---If a callback is provided, only projects for which the callback returns true will be included.
+---
+---@param solution_file_path string: The path to the .sln solution file.
+---@param filter_fn? fun(project: DotnetProject): boolean Optional predicate to filter projects.
+---@return DotnetProject[]: A list of DotnetProject objects from the solution, optionally filtered.
+function M.get_projects_from_sln_async(solution_file_path, filter_fn)
+  local result = cache.get(solution_file_path, function()
+    local project_lines
+    local co = coroutine.running()
+    assert(co, "get_projects_from_sln_async must be called within a coroutine")
+
+    local stdout
+    local stderr
+    local cmd = require("easy-dotnet.dotnet_cli").list_projects(solution_file_path)
+    vim.fn.jobstart(cmd, {
+      stdout_buffered = true,
+      stderr_buffered = true,
+      on_stdout = function(_, data) stdout = data end,
+      on_stderr = function(_, data) stderr = data end,
+      on_exit = function(_, code)
+        if code == 0 then
+          project_lines = get_project_paths_from_stdout(stdout)
+        else
+          error("Command failed: " .. cmd)
+          vim.print(stderr)
+        end
+        coroutine.resume(co)
+      end,
+    })
+    coroutine.yield()
+
+    local remaining = #project_lines
+    for _, proj_path in ipairs(project_lines) do
+      local project_file_path = generate_absolute_path_for_project(proj_path, solution_file_path)
+      require("easy-dotnet.parsers.csproj-parse").preload_msbuild_properties(project_file_path, function()
+        remaining = remaining - 1
+        if remaining == 0 then coroutine.resume(co) end
+      end)
+    end
+
+    if remaining > 0 then coroutine.yield() end
+
+    local projects = get_all_projects_from_paths(project_lines, solution_file_path)
+    if filter_fn then return vim.tbl_filter(filter_fn, projects) end
+
+    return projects
+  end)
+
+  return result
+end
+
 ---Parses a .sln file and returns a list of DotnetProject objects.
 ---If a callback is provided, only projects for which the callback returns true will be included.
 ---
@@ -130,26 +201,18 @@ end
 function M.get_projects_from_sln(solution_file_path, filter_fn)
   local result = cache.get(solution_file_path, function()
     local cmd = require("easy-dotnet.dotnet_cli").list_projects(solution_file_path)
-    local data = vim.fn.systemlist(cmd)
+    local stdout = vim.fn.systemlist(cmd)
 
-    local function trim(s) return s:match("^%s*(.-)%s*$") end
-    local project_lines = {}
-    for _, line in ipairs(data) do
-      local t = trim(line)
-      if t:match("%.csproj$") or t:match("%.fsproj$") then table.insert(project_lines, t) end
-    end
+    if vim.v.shell_error ~= 0 then error("Command failed: " .. cmd) end
+
+    local project_lines = get_project_paths_from_stdout(stdout)
 
     polyfills.iter(project_lines):each(function(proj_path)
       local project_file_path = generate_absolute_path_for_project(proj_path, solution_file_path)
       require("easy-dotnet.parsers.csproj-parse").preload_msbuild_properties(project_file_path)
     end)
 
-    local projects = polyfills.tbl_map(function(proj_path)
-      local csproj_parser = require("easy-dotnet.parsers.csproj-parse")
-      local project_file_path = generate_absolute_path_for_project(proj_path, solution_file_path)
-      local project = csproj_parser.get_project_from_project_file(project_file_path)
-      return project
-    end, project_lines)
+    local projects = get_all_projects_from_paths(project_lines, solution_file_path)
 
     if filter_fn then return vim.tbl_filter(filter_fn, projects) end
 


### PR DESCRIPTION
Previously background scanning would cache all msbuild properties. This gave a huge perf boost. With the introduction of #356 I forgot to extend the background scanning. When calling on `get_projects_from_sln` it would call `dotnet sln x list` synchronously. On windows this causes about ~1.7s lag in a "normal" project.

With this change the background scanning is extended to call `get_projects_from_sln_async`. With background scanning enabled windows users will se a performance diff of `~1.7s` when calling any command that invokes `get_projects_from_sln` for the first time during a session
