### PR TITLE
feat(buffer test execution): run tests with cursor anywhere inside method declaration

### DIFF
--- a/lua/easy-dotnet/constants.lua
+++ b/lua/easy-dotnet/constants.lua
@@ -29,6 +29,7 @@ M.signs = {
   EasyDotnetTestFailed = "EasyDotnetTestFailed",
   EasyDotnetTestSkipped = "EasyDotnetTestSkipped",
   EasyDotnetTestError = "EasyDotnetTestError",
+  EasyDotnetTestInProgress = "EasyDotnetTestInProgress",
 }
 
 return M

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -84,6 +84,7 @@ local function define_highlights_and_signs(merged_opts)
   vim.fn.sign_define(constants.signs.EasyDotnetTestSign, { text = icons.test, texthl = "Character" })
   vim.fn.sign_define(constants.signs.EasyDotnetTestPassed, { text = icons.passed, texthl = "EasyDotnetTestRunnerPassed" })
   vim.fn.sign_define(constants.signs.EasyDotnetTestFailed, { text = icons.failed, texthl = "EasyDotnetTestRunnerFailed" })
+  vim.fn.sign_define(constants.signs.EasyDotnetTestInProgress, { text = icons.reload, texthl = "EasyDotnetTestRunnerRunning" })
   vim.fn.sign_define(constants.signs.EasyDotnetTestSkipped, { text = icons.skipped })
   vim.fn.sign_define(constants.signs.EasyDotnetTestError, { text = "E", texthl = "EasyDotnetTestRunnerFailed" })
 end


### PR DESCRIPTION
First of all, this plugin is amazing. Thank you Gustav.

Ok so the goal of this is to be able to run tests in buffer with the cursor somewhere inside the wanted test method instead of having to be on the method line itself. This makes the run-in-buffer much easier to use.

Also added the gutter sign with the already configured `reload` sign so we get visual feedback.

This can be changed and improved upon, also not sure if adding the require on treesitter is a deal breaker?

![image](https://github.com/user-attachments/assets/9307ae60-8a11-47ba-8e6c-0e2cc4cc63b4)
![image](https://github.com/user-attachments/assets/3d6a9ad1-edfb-48e5-8061-f2228afb4386)
