### PR TITLE
fix(dotnet outdated): escape `-` in package names

### DIFF
--- a/lua/easy-dotnet/outdated/outdated.lua
+++ b/lua/easy-dotnet/outdated/outdated.lua
@@ -56,12 +56,15 @@ end
 local function find_package_in_buffer(package_name, pattern_type)
   local buf = vim.api.nvim_get_current_buf()
 
+  -- Escape dots and hyphens in package name
+  local escaped_package_name = package_name:gsub("[%.%-]", "%%%1")
+
   -- Define the pattern based on the type
   local pattern
   if pattern_type == PATTERN_TYPE_REFERENCE then
-    pattern = '<PackageReference Include="' .. package_name:gsub("%.", "%%.") .. '"'
+    pattern = '<PackageReference Include="' .. escaped_package_name .. '"'
   elseif pattern_type == PATTERN_TYPE_VERSION then
-    pattern = '<PackageVersion Include="' .. package_name:gsub("%.", "%%.") .. '"'
+    pattern = '<PackageVersion Include="' .. escaped_package_name .. '"'
   else
     error("Invalid pattern_type: " .. tostring(pattern_type))
     return nil


### PR DESCRIPTION
When doing `:Dotnet outdated` in my directory.packages.props, a warning appears informing that the Magick.NET-Q8-AnyCPU nuget is not found on the file.

Looks like the code was escaping dots `.` but not hypens `-` in the package name.

This PR adds the hypen as a escaped character, since the lua match takes those as regex special characters.

When doing `:Dotnet outdated` in my `directory.packages.props`, a warning appears informing that the **Magick.NET-Q8-AnyCPU nuget** is not found on the file.

Looks like the code was escaping dots `.` but not hyphens `-` in the package name. 

This PR adds the hyphen as an escaped character.