### PR TITLE
feat: add build solution quickfix and close quickfix list on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Although not *required* by the plugin, it is highly recommended to install one o
 ||  
 | `dotnet.build()` | `dotnet build <TS> <DArgs>` |
 | `dotnet.build_solution()` | `dotnet build <sln> <DArgs>` |
+| `dotnet.build_solution_quickfix()` | `dotnet build <sln> <DArgs>` and opens build errors in the quickfix list |
 | `dotnet.build_quickfix()` | `dotnet build <TS> <DArgs>` and opens build errors in the quickfix list |
 | `dotnet.build_default()` | `dotnet build <TS Default> <DArgs>` |
 | `dotnet.build_default_quickfix()` | `dotnet build <TS Default> <DArgs>` and opens build errors in the quickfix list |
@@ -326,6 +327,7 @@ dotnet.ef_database_update_pick()
 dotnet.createfile(path: string)                                    
 dotnet.build()                           
 dotnet.build_solution()
+dotnet.build_solution_quickfix()
 dotnet.build_quickfix()                 
 dotnet.build_default()                 
 dotnet.build_default_quickfix()       
@@ -361,6 +363,7 @@ Dotnet test solution
 Dotnet build
 Dotnet build quickfix
 Dotnet build solution
+Dotnet build solution quickfix
 Dotnet build default
 Dotnet build default quickfix
 Dotnet add package

--- a/lua/easy-dotnet/actions/init.lua
+++ b/lua/easy-dotnet/actions/init.lua
@@ -3,6 +3,7 @@ local M = {}
 M.build = require("easy-dotnet.actions.build").build_project_picker
 M.build_quickfix = require("easy-dotnet.actions.build").build_project_quickfix
 M.build_solution = require("easy-dotnet.actions.build").build_solution
+M.build_solution_quickfix = require("easy-dotnet.actions.build").build_solution_quickfix
 M.restore = require("easy-dotnet.actions.restore").restore
 M.test = require("easy-dotnet.actions.test").run_test_picker
 M.test_solution = require("easy-dotnet.actions.test").test_solution

--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -166,6 +166,12 @@ M.build = {
         actions.build_solution(terminal, passthrough_dotnet_cli_args_handler(args))
       end,
       passthrough = true,
+      subcommands = {
+        quickfix = {
+          handle = function(args) actions.build_solution_quickfix(passthrough_dotnet_cli_args_handler(args)) end,
+          passthrough = true,
+        },
+      },
     },
     default = {
       handle = function(args, options)


### PR DESCRIPTION
I find the `build quickfix` a really useful feature. And saw that the option was not available at solution level. 

Also while testing this, I found out that when re-executing any build quickfix option without errors, the errors didn't disappear on the quickfix list. If there was any from a previous execution of course.

So this PR seeks to:
- Add the `dotnet build solution quickfix` in all entry points.
- Clear and close the quickfix list when there are no errors.
- Little refactor to reduce code duplication. I think that this also fixed the `logger.info("Build failed")` instead of using the spinner in one case.