### PR TITLE
fix: windows (cmd) jq argument quotes

### DIFF
--- a/lua/easy-dotnet/completion/blink.lua
+++ b/lua/easy-dotnet/completion/blink.lua
@@ -34,7 +34,7 @@ function M:get_completions(ctx, callback)
   if inside_include then
     local search_term = inside_include:gsub('%Include="', "")
     local command = cli.package_search(search_term, true, false, 5)
-    vim.fn.jobstart(string.format("%s | jq '.searchResult | .[] | .packages | .[] | .id'", command), {
+    vim.fn.jobstart(string.format('%s | jq ".searchResult | .[] | .packages | .[] | .id"', command), {
       stdout_buffered = true,
       on_stdout = function(_, data)
         local items = polyfills.tbl_map(function(i)
@@ -48,7 +48,7 @@ function M:get_completions(ctx, callback)
   elseif inside_version then
     local package_name = current_line:match('Include="([^"]+)"')
     local command = cli.package_search(package_name, true, true)
-    vim.fn.jobstart(string.format("%s | jq '.searchResult[].packages[].version'", command), {
+    vim.fn.jobstart(string.format('%s | jq ".searchResult[].packages[].version"', command), {
       stdout_buffered = true,
       on_stdout = function(_, data)
         local index = 0

--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -75,7 +75,7 @@ M.package_completion_cmp = {
     if inside_include then
       local search_term = inside_include:gsub('%Include="', "")
       local command = cli.package_search(search_term, true, false, 5)
-      vim.fn.jobstart(string.format("%s | jq '.searchResult | .[] | .packages | .[] | .id'", command), {
+      vim.fn.jobstart(string.format('%s | jq ".searchResult | .[] | .packages | .[] | .id"', command), {
         stdout_buffered = true,
         on_stdout = function(_, data)
           local items = polyfills.tbl_map(function(i) return { label = i:gsub("\r", ""):gsub("\n", ""):gsub('"', ""), kind = 18 } end, data)
@@ -85,7 +85,7 @@ M.package_completion_cmp = {
     elseif inside_version then
       local package_name = current_line:match('Include="([^"]+)"')
       local command = cli.package_search(package_name, true, true)
-      vim.fn.jobstart(string.format("%s | jq '.searchResult[].packages[].version'", command), {
+      vim.fn.jobstart(string.format('%s | jq ".searchResult[].packages[].version"', command), {
         stdout_buffered = true,
         on_stdout = function(_, data)
           local index = 0

--- a/lua/easy-dotnet/nuget.lua
+++ b/lua/easy-dotnet/nuget.lua
@@ -16,7 +16,7 @@ local function reverse_list(list)
 end
 
 local function get_all_versions(package)
-  local command = string.format("dotnet package search %s --exact-match --format json | jq '.searchResult[].packages[].version'", package)
+  local command = string.format('dotnet package search %s --exact-match --format json | jq ".searchResult[].packages[].version"', package)
   local versions = vim.fn.split(vim.fn.system(command):gsub('"', ""), "\n")
   return reverse_list(versions)
 end
@@ -77,7 +77,7 @@ M.search_nuget = function(project_path)
 end
 
 local function get_package_refs(project_path)
-  local command = string.format("dotnet list %s package --format json | jq '[.projects[].frameworks[].topLevelPackages[] | {name: .id, version: .resolvedVersion}]'", project_path)
+  local command = string.format('dotnet list %s package --format json | jq "[.projects[].frameworks[].topLevelPackages[] | {name: .id, version: .resolvedVersion}]"', project_path)
   local out = vim.fn.system(command)
   if vim.v.shell_error then logger.error("Failed to get packages for " .. project_path) end
   local packages = vim.fn.json_decode(out)

--- a/lua/easy-dotnet/project-view/render.lua
+++ b/lua/easy-dotnet/project-view/render.lua
@@ -91,7 +91,7 @@ local function discover_package_references(project)
   --Incase of out of mem, do some jq tricks to read line by line
   --TODO: research the frameworks[]
   --TODO: is it possible to resolve transitive dependencies?
-  local command = string.format("dotnet list %s package --format json | jq '[.projects[].frameworks[].topLevelPackages[] | {name: .id, version: .resolvedVersion}]'", project.path)
+  local command = string.format('dotnet list %s package --format json | jq "[.projects[].frameworks[].topLevelPackages[] | {name: .id, version: .resolvedVersion}]"', project.path)
   vim.fn.jobstart(command, {
     stdout_buffered = true,
     on_exit = function(_, code)


### PR DESCRIPTION
hey @GustavEikaas 
Thanks for the great plugin

For cmd in windows, jq seems only supports double quotes.

Double quotes are working fine in linux and Powershell too, not sure about mac though, as I don't have a mac to test against.

Thanks

