### PR TITLE
Use nvim_set_buf_extmark instead of sign_place

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,28 +926,3 @@ If you want to be prompted to select a profile, remember to pass false as the la
 </details>
 
 
-## Signs
-
-<details>
-<summary>Click to see all signs</summary>
-
-<!--sign start-->
-
-  ```lua
-  --override example
-  vim.fn.sign_define("EasyDotnetTestSign", { text = "", texthl = "Character" })
-  ```
-
-| Sign                           | Highlight                    |
-| ------------------------------ | ---------------------------- |
-| **EasyDotnetTestSign**         | Character                    |
-| **EasyDotnetTestPassed**       | EasyDotnetTestRunnerPassed   |
-| **EasyDotnetTestFailed**       | EasyDotnetTestRunnerFailed   |
-| **EasyDotnetTestSkipped**      | (none)                       |
-| **EasyDotnetTestError**        | EasyDotnetTestRunnerFailed   |
-
-<!-- sign-end -->
-
-</details>
-
-

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -62,7 +62,7 @@ local function present_command_picker()
   end, "Select command", false)
 end
 
-local function define_highlights_and_signs(merged_opts)
+local function define_highlights()
   vim.api.nvim_set_hl(0, "EasyDotnetPackage", {
     fg = "#000000",
     bg = "#ffffff",
@@ -204,7 +204,7 @@ local function auto_install_easy_dotnet()
 end
 M.setup = function(opts)
   local merged_opts = require("easy-dotnet.options").set_options(opts)
-  define_highlights_and_signs(merged_opts)
+  define_highlights()
   check_picker_config(merged_opts)
 
   vim.api.nvim_create_user_command("Dotnet", function(commandOpts)

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -80,14 +80,6 @@ local function define_highlights_and_signs(merged_opts)
   vim.api.nvim_set_hl(0, constants.highlights.EasyDotnetTestRunnerPassed, { link = "DiagnosticOk" })
   vim.api.nvim_set_hl(0, constants.highlights.EasyDotnetTestRunnerFailed, { link = "DiagnosticError" })
   vim.api.nvim_set_hl(0, constants.highlights.EasyDotnetTestRunnerRunning, { link = "DiagnosticWarn" })
-
-  local icons = merged_opts.test_runner.icons
-  vim.fn.sign_define(constants.signs.EasyDotnetTestSign, { text = icons.test, texthl = "Character" })
-  vim.fn.sign_define(constants.signs.EasyDotnetTestPassed, { text = icons.passed, texthl = "EasyDotnetTestRunnerPassed" })
-  vim.fn.sign_define(constants.signs.EasyDotnetTestFailed, { text = icons.failed, texthl = "EasyDotnetTestRunnerFailed" })
-  vim.fn.sign_define(constants.signs.EasyDotnetTestInProgress, { text = icons.reload, texthl = "EasyDotnetTestRunnerRunning" })
-  vim.fn.sign_define(constants.signs.EasyDotnetTestSkipped, { text = icons.skipped })
-  vim.fn.sign_define(constants.signs.EasyDotnetTestError, { text = "E", texthl = "EasyDotnetTestRunnerFailed" })
 end
 
 local register_legacy_functions = function()

--- a/lua/easy-dotnet/test-signs.lua
+++ b/lua/easy-dotnet/test-signs.lua
@@ -119,7 +119,7 @@ function M.add_gutter_test_signs()
     if (node.type == "test" or node.type == "test_group") and compare_paths(node.file_path, curr_file) then
       is_test_file = true
       --INFO: line number for MTP is on the [Test] attribute. VSTest is on the method_declaration
-      local line_offset = node.line_number - (node.is_MTP and 0 or 1)
+      local line_offset = node.line_number - 1 - (node.is_MTP and 0 or 1)
 
       vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
         id = node.line_number,

--- a/lua/easy-dotnet/test-signs.lua
+++ b/lua/easy-dotnet/test-signs.lua
@@ -110,8 +110,6 @@ end
 
 function M.add_gutter_test_signs()
   local options = require("easy-dotnet.test-runner.render").options
-  local signs = constants.signs
-  local sign_ns = constants.sign_namespace
   local is_test_file = false
   local bufnr = vim.api.nvim_get_current_buf()
   local curr_file = vim.api.nvim_buf_get_name(bufnr)
@@ -122,17 +120,43 @@ function M.add_gutter_test_signs()
       is_test_file = true
       --INFO: line number for MTP is on the [Test] attribute. VSTest is on the method_declaration
       local line_offset = node.line_number - (node.is_MTP and 0 or 1)
-      vim.fn.sign_place(0, sign_ns, signs.EasyDotnetTestSign, bufnr, { lnum = line_offset, priority = 20 })
+
+      vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
+        id = node.line_number,
+        sign_text = options.icons.test,
+        priority = 20,
+        sign_hl_group = constants.highlights.EasyDotnetTestRunnerProject,
+      })
 
       if node.icon then
         if node.icon == options.icons.failed then
-          vim.fn.sign_place(0, sign_ns, signs.EasyDotnetTestFailed, bufnr, { lnum = line_offset, priority = 20 })
+          vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
+            id = node.line_number,
+            sign_text = options.icons.failed,
+            priority = 20,
+            sign_hl_group = constants.highlights.EasyDotnetTestRunnerFailed,
+          })
         elseif node.icon == options.icons.skipped then
-          vim.fn.sign_place(0, sign_ns, signs.EasyDotnetTestSkipped, bufnr, { lnum = line_offset, priority = 20 })
+          vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
+            id = node.line_number,
+            sign_text = options.icons.skipped,
+            priority = 20,
+            sign_hl_group = constants.highlights.EasyDotnetTestRunnerTest,
+          })
         elseif node.icon == "<Running>" then
-          vim.fn.sign_place(0, sign_ns, signs.EasyDotnetTestInProgress, bufnr, { lnum = line_offset, priority = 20 })
+          vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
+            id = node.line_number,
+            sign_text = options.icons.reload,
+            priority = 20,
+            sign_hl_group = constants.highlights.EasyDotnetTestRunnerRunning,
+          })
         elseif node.icon == options.icons.passed then
-          vim.fn.sign_place(0, sign_ns, signs.EasyDotnetTestPassed, bufnr, { lnum = line_offset, priority = 20 })
+          vim.api.nvim_buf_set_extmark(bufnr, constants.ns_id, line_offset, 0, {
+            id = node.line_number,
+            sign_text = options.icons.passed,
+            priority = 20,
+            sign_hl_group = constants.highlights.EasyDotnetTestRunnerPassed,
+          })
         end
       end
     end


### PR DESCRIPTION
Quick-fix for #399.

I only tested with LazyVim on macOS. 

- [x] replace `vim.fn.sign_place` with `nvim_set_buf_extmark`
- [x] Test on MacOs
- [x] Test on Windows
- [ ] Update readme