### PR TITLE
feat: snacks.explorer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ Adding the following autocmd to your config will allow for creating files using 
     })
 ```
 
-### Integrating with snacks.explorer
+### Integrating with snacks explorer
 
 ```lua
   {

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
     - [Integrating with nvim-tree](#integrating-with-nvim-tree)
     - [Integrating with neo-tree](#integrating-with-neo-tree)
     - [Integrating with mini.files](#integrating-with-mini-files)
+    - [Integrating with snacks.explorer](#integrating-with-snacks-explorer)
 14. [EntityFramework](#entityframework)
     - [Database](#database)
     - [Migrations](#migrations)
@@ -706,6 +707,44 @@ Adding the following autocmd to your config will allow for creating files using 
     })
 ```
 
+### Integrating with snacks.explorer
+
+```lua
+  {
+    "folke/snacks.nvim",
+    ---@type snacks.Config
+    opts = {
+      picker = {
+        sources = {
+          explorer = {
+            win = {
+              list = {
+                keys = {
+                  ["A"] = "explorer_add_dotnet",
+                },
+              },
+            },
+            actions = {
+              explorer_add_dotnet = function(picker)
+                local dir = picker:dir()
+                local tree = require("snacks.explorer.tree")
+                local actions = require("snacks.explorer.actions")
+                local easydotnet = require("easy-dotnet")
+
+                easydotnet.create_new_item(dir, function(item_path)
+                  tree:open(dir)
+                  tree:refresh(dir)
+                  actions.update(picker, { target = item_path })
+                end)
+              end,
+            },
+          },
+        },
+      },
+    },
+  },
+
+```
 
 ## EntityFramework
 Common EntityFramework commands have been added mainly to reduce the overhead of writing `--project .. --startup-project ..`. 

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -233,40 +233,43 @@ local function name_input_sync() return vim.fn.input("Enter name:") end
 M.create_new_item = function(path, cb)
   path = path or "."
   local template = require("easy-dotnet.picker").pick_sync(nil, {
-    { value = "buildprops", display = "MSBuild Directory.Build.props File", type = "MSBuild/props" },
-    { value = "packagesprops", display = "MSBuild Directory.Packages.props File", type = "MSBuild/props" },
-    { value = "buildtargets", display = "MSBuild Directory.Build.targets File", type = "MSBuild/props" },
-    { value = "apicontroller", display = "Api Controller", type = "Code" },
-    { value = "interface", display = "Interface", type = "Code" },
-    { value = "class", display = "Class", type = "Code" },
-    { value = "mvccontroller", display = "MVC Controller", type = "Code" },
-    { value = "viewimports", display = "MVC ViewImports", type = "Code" },
-    { value = "viewstart", display = "MVC ViewStart", type = "Code" },
-    { value = "razorcomponent", display = "Razor Component", type = "Code" },
-    { value = "page", display = "Razor Page", type = "Code" },
-    { value = "view", display = "Razor View", type = "Code" },
-    { value = "nunit-test", display = "NUnit 3 Test Item", type = "Test/NUnit" },
-    { value = "gitignore", display = "Dotnet Gitignore File", type = "Config" },
-    { value = "tool-manifest", display = "Dotnet Local Tool Manifest File", type = "Config" },
-    { value = "editorconfig", display = "EditorConfig File", type = "Config" },
-    { value = "globaljson", display = "Global.json File", type = "Config" },
-    { value = "nugetconfig", display = "NuGet Config", type = "Config" },
-    { value = "webconfig", display = "Web Config", type = "Config" },
-    { value = "solution", display = "Solution", type = "Config" },
+    { value = "buildprops", display = "MSBuild Directory.Build.props File", type = "MSBuild/props", predefined_file_name = "Directory.Build.props" },
+    { value = "packagesprops", display = "MSBuild Directory.Packages.props File", type = "MSBuild/props", predefnied_file_name = "Directory.Packages.props" },
+    { value = "buildtargets", display = "MSBuild Directory.Build.targets File", type = "MSBuild/props", predefined_file_name = "Directory.Build.targets" },
+    { value = "apicontroller", display = "Api Controller", type = "Code", extension = ".cs" },
+    { value = "interface", display = "Interface", type = "Code", extension = ".cs" },
+    { value = "class", display = "Class", type = "Code", extension = ".cs" },
+    { value = "mvccontroller", display = "MVC Controller", type = "Code", extension = ".cs" },
+    { value = "viewimports", display = "MVC ViewImports", type = "Code", extension = ".cshtml" },
+    { value = "viewstart", display = "MVC ViewStart", type = "Code", extension = ".cshtml" },
+    { value = "razorcomponent", display = "Razor Component", type = "Code", extension = ".razor" },
+    { value = "page", display = "Razor Page", type = "Code", extension = ".cshtml" },
+    { value = "view", display = "Razor View", type = "Code", extension = ".cshtml" },
+    { value = "nunit-test", display = "NUnit 3 Test Item", type = "Test/NUnit", extension = ".cs" },
+    { value = "gitignore", display = "Dotnet Gitignore File", type = "Config", file_name = ".gitignore" },
+    { value = "tool-manifest", display = "Dotnet Local Tool Manifest File", type = "Config", predefined_file_name = "dotnet-tools.json" },
+    { value = "editorconfig", display = "EditorConfig File", type = "Config", predefined_file_name = ".editorconfig" },
+    { value = "globaljson", display = "Global.json File", type = "Config", predefined_file_name = "global.json" },
+    { value = "nugetconfig", display = "NuGet Config", type = "Config", predefined_file_name = "nuget.config" },
+    { value = "webconfig", display = "Web Config", type = "Config", predefined_file_name = "web.config" },
+    { value = "solution", display = "Solution", type = "Config", extension = ".sln" },
   }, "Type")
 
   assert(template)
 
+  path = path or "."
   local args = ""
+  local file_name = ""
 
-  if template.type == "Code" then
+  if template.predefined_file_name ~= nil then
+    file_name = template.predefined_file_name
+  else
     local name = name_input_sync()
-    args = string.format("-n %s", name)
-  elseif template.type == "Config" then
-    local name = name_input_sync()
-    args = string.format("-n %s", name)
-  elseif template.type == "Test/NUnit" then
-    local name = name_input_sync()
+    if not name or name:match("^%s*$") then
+      logger.error("No name provided")
+      return
+    end
+    file_name = name .. template.extension
     args = string.format("-n %s", name)
   end
 

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -234,7 +234,7 @@ M.create_new_item = function(path, cb)
   path = path or "."
   local template = require("easy-dotnet.picker").pick_sync(nil, {
     { value = "buildprops", display = "MSBuild Directory.Build.props File", type = "MSBuild/props", predefined_file_name = "Directory.Build.props" },
-    { value = "packagesprops", display = "MSBuild Directory.Packages.props File", type = "MSBuild/props", predefnied_file_name = "Directory.Packages.props" },
+    { value = "packagesprops", display = "MSBuild Directory.Packages.props File", type = "MSBuild/props", predefined_file_name = "Directory.Packages.props" },
     { value = "buildtargets", display = "MSBuild Directory.Build.targets File", type = "MSBuild/props", predefined_file_name = "Directory.Build.targets" },
     { value = "apicontroller", display = "Api Controller", type = "Code", extension = ".cs" },
     { value = "interface", display = "Interface", type = "Code", extension = ".cs" },
@@ -246,7 +246,7 @@ M.create_new_item = function(path, cb)
     { value = "page", display = "Razor Page", type = "Code", extension = ".cshtml" },
     { value = "view", display = "Razor View", type = "Code", extension = ".cshtml" },
     { value = "nunit-test", display = "NUnit 3 Test Item", type = "Test/NUnit", extension = ".cs" },
-    { value = "gitignore", display = "Dotnet Gitignore File", type = "Config", file_name = ".gitignore" },
+    { value = "gitignore", display = "Dotnet Gitignore File", type = "Config", predefined_file_name = ".gitignore" },
     { value = "tool-manifest", display = "Dotnet Local Tool Manifest File", type = "Config", predefined_file_name = "dotnet-tools.json" },
     { value = "editorconfig", display = "EditorConfig File", type = "Config", predefined_file_name = ".editorconfig" },
     { value = "globaljson", display = "Global.json File", type = "Config", predefined_file_name = "global.json" },
@@ -259,7 +259,7 @@ M.create_new_item = function(path, cb)
 
   path = path or "."
   local args = ""
-  local file_name = ""
+  local file_name
 
   if template.predefined_file_name ~= nil then
     file_name = template.predefined_file_name

--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -285,7 +285,10 @@ M.create_new_item = function(path, cb)
         vim.print(stdout)
         logger.error("Command failed")
       end
-      if cb then cb() end
+      if cb then
+        local file_path = vim.fs.normalize(vim.fs.joinpath(path, file_name))
+        cb(file_path)
+      end
     end,
   })
 end

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -16,9 +16,9 @@ local function wrap(callback)
     else
       -- If not, create a new coroutine and resume it
       local co = coroutine.create(callback)
-      local s = ...
+      local args = { ... }
       local handle = function()
-        local success, err = coroutine.resume(co, s)
+        local success, err = coroutine.resume(co, unpack(args))
         if not success then print("Coroutine failed: " .. err) end
       end
       handle()


### PR DESCRIPTION
During integration with snacks.explorer I noticed that callback passed to `create_new_item` function is not executed. As it turned out the `wrap` function was only passing first argument to coroutine.

Right now, the callback also receives the path of the created item (so in the case of `snacks.explorer`, the newly created file is focused). I’ve extended the logic a bit so that the user is not always prompted for a file name, since not all templates support this.

Since I am quite new to lua/neovim api, I am open to any suggestions and criticism!

Commits:
- Pass all arguments to coroutine
- Add snacks.explorer integration example
- Determine if input prompt is needed
- Pass created item path to callback
