### PR TITLE
fix: project reference path parsed wrong

### DIFF
--- a/lua/easy-dotnet/project-view/render.lua
+++ b/lua/easy-dotnet/project-view/render.lua
@@ -256,7 +256,7 @@ local function remove_project_keymap(ref)
     key = "r",
     handler = function()
       local cleanup = M.append_job("Removing project reference")
-      vim.fn.jobstart(string.format("dotnet remove %s reference %s ", M.project.path, ref), {
+      vim.fn.jobstart({ "dotnet", "remove", M.project.path, "reference", ref }, {
         on_exit = function(_, code)
           cleanup()
           if code ~= 0 then


### PR DESCRIPTION
For the issue #426

So basically the issue is when we're working a path with backslashes jobstart cannot parse the path properly.