### PR TITLE
fix: not running inside a coroutine and parse error

### DIFF
--- a/lua/easy-dotnet/picker/_fzf.lua
+++ b/lua/easy-dotnet/picker/_fzf.lua
@@ -24,14 +24,14 @@ M.nuget_search = function()
   local results = {}
   client:initialize(function()
     require("fzf-lua").fzf_live(function(prompt)
-      return function(add_item, finished)
-        local res = nuget_search_rpc(prompt, client)
+      return coroutine.wrap(function(add_item, finished)
+        local res = nuget_search_rpc(prompt[1], client)
         results = res
         for _, r in ipairs(res) do
           add_item(r.display)
         end
         finished()
-      end
+      end)
     end, {
       actions = {
         ["default"] = function(selected)


### PR DESCRIPTION
Fix for #459

nuget_search_rpc is expected to be called within a coroutine as far as i understand. And after that I realized that prompt param is passed as a 1 member array not a string directly with another error. Used first (and only) member of prompt as a parameter.
