### PR TITLE
fix(init): avoid yielding across C boundary in get_solutions_async

### DIFF
--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -165,7 +165,9 @@ local function get_solutions_async(cb)
     depth = 5,
     silent = true,
     on_exit = function(output)
-      vim.schedule(function() wrap(cb)(output) end)
+      vim.schedule(function()
+        coroutine.wrap(function() cb(output) end)()
+      end)
     end,
   })
 end


### PR DESCRIPTION
## Summary
Prevents a coroutine yield across a C boundary by running the scan callback inside a Lua coroutine instead of directly inside a scheduled C callback.

## Problem
Opening a .NET repo with a .sln triggers background scanning. The callback chain eventually calls `parsers/sln-parse.lua:get_projects_from_sln_async`, whose cache value_factory uses `coroutine.yield()`. Because the call originated from `vim.schedule` (C), Neovim errors with:

> attempt to yield across C-call boundary

<img width="1216" height="500" alt="2025-08-08T00:23:28,981517683-04:00" src="https://github.com/user-attachments/assets/46eb07a7-235f-4c55-a9a3-7395963704ce" />

## Fix
Wrap vim.schedule(..) around a lua coroutine

## Repro (before)
- Neovim: 0.11.3
- OS: Fedora Linux
- dotnet: 9.0.108
- Error appears on startup:
  `attempt to yield across C-call boundary` (from `sln-parse.lua:199`).

## Validation (after)
- Same environment.
- No error on startup; projects load as expected.
- Existing behavior unchanged (still scheduled, still async).
