### PR TITLE
feat(new): rpc template engine

### DIFF
--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -1,6 +1,5 @@
 local polyfills = require("easy-dotnet.polyfills")
 local logger = require("easy-dotnet.logger")
-local options = require("easy-dotnet.options")
 local M = {}
 
 local function sln_add_project(sln_path, project, cb)
@@ -17,6 +16,7 @@ local function sln_add_project(sln_path, project, cb)
 end
 
 local make_project_name = function(name, sln_name)
+  local options = require("easy-dotnet.options")
   if options.get_option("new").project.prefix == "sln" then return sln_name .. "." .. name end
   return name
 end


### PR DESCRIPTION
Started using `Microsoft.TemplateEngine` as opposed to `dotnet cli`. This allows a lot more flexibility in terms of user-installed templates and arbitrary options.