### PR TITLE
feat: rpc nuget restore

### DIFF
--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -156,6 +156,7 @@ local M = {
     server = {
       ---@type nil | "Off" | "Critical" | "Error" | "Warning" | "Information" | "Verbose" | "All"
       log_level = nil,
+      use_visual_studio = false,
     },
     enable_filetypes = true,
     auto_bootstrap_namespace = {

--- a/lua/easy-dotnet/rpc/dotnet-client.lua
+++ b/lua/easy-dotnet/rpc/dotnet-client.lua
@@ -166,10 +166,12 @@ end
 
 function M:_initialize(cb)
   local finished = jobs.register_job({ name = "Initializing...", on_success_text = "Client initialized" })
+  local use_visual_studio = require("easy-dotnet.options").options.server.use_visual_studio == true
   self._client.request("initialize", {
     request = {
       clientInfo = { name = "EasyDotnet", version = "1.0.0" },
       projectInfo = { rootDir = vim.fs.normalize(vim.fn.getcwd()) },
+      options = { useVisualStudio = use_visual_studio },
     },
   }, function(response)
     local crash = handle_rpc_error(response)
@@ -197,15 +199,37 @@ end
 
 function M:nuget_restore(targetPath, cb)
   local finished = jobs.register_job({ name = "Restoring packages...", on_error_text = "Failed to restore nuget packages", on_success_text = "Nuget packages restored" })
-  self._client.request("msbuild/restore", { targetPath = targetPath }, function(response)
+  self._client.request("nuget/restore", { targetPath = targetPath }, function(response)
     local crash = handle_rpc_error(response)
     if crash then
       finished(false)
       return
     end
-    --TODO: check response body for success info
-    finished(true)
-    if cb then cb(response) end
+    local result = response.result or {}
+    local pending = 2
+
+    local function done()
+      if pending == 0 then
+        finished(result.success)
+        if cb then cb(result) end
+      end
+    end
+
+    if result.warnings and result.warnings.token then
+      self._client:request_property_enumerate(response.result.warnings.token, nil, function(warnings)
+        response.result.warnings = warnings
+        pending = pending - 1
+        done()
+      end)
+    end
+
+    if result.errors and result.errors.token then
+      self._client:request_property_enumerate(response.result.errors.token, nil, function(errors)
+        response.result.errors = errors
+        pending = pending - 1
+        done()
+      end)
+    end
   end)
 end
 

--- a/lua/easy-dotnet/rpc/rpc-client.lua
+++ b/lua/easy-dotnet/rpc/rpc-client.lua
@@ -260,8 +260,8 @@ end
 function M:request_property_enumerate(token, on_yield, on_finished, on_error)
   local all_results = {}
 
-  local function handle_next(token)
-    self._enumerable_next(token, function(res)
+  local function handle_next(enumerable_token)
+    self._enumerable_next(enumerable_token, function(res)
       if res.error and on_error then on_error(res) end
       if res.result then
         if #res.result.values > 0 then
@@ -269,7 +269,7 @@ function M:request_property_enumerate(token, on_yield, on_finished, on_error)
           if on_yield then on_yield(res.result.values) end
         end
         if res.result.finished == false then
-          handle_next(token)
+          handle_next(enumerable_token)
         else
           if on_finished then on_finished(all_results) end
         end

--- a/lua/easy-dotnet/rpc/rpc-client.lua
+++ b/lua/easy-dotnet/rpc/rpc-client.lua
@@ -15,6 +15,7 @@ local M = {
 ---@field connect fun(cb: fun()): nil
 ---@field request fun(method: DotnetPipeMethod, params: table, callback: fun(result: RPC_Response), options?: RpcRequestOptions): integer|false
 ---@field request_enumerate fun(self: StreamJsonRpc, method: DotnetPipeMethod, params: table, on_yield: fun(result: table)|nil, on_finished: fun(results: table[])|nil, on_error: fun(res: RPC_Response)|nil): integer|false
+---@field request_property_enumerate fun(self: StreamJsonRpc, token: string, on_yield: fun(result: table)|nil, on_finished: fun(results: table[])|nil, on_error: fun(res: RPC_Response)|nil): nil
 ---@field notify fun(method: string, params: table): boolean
 ---@field cancel fun(id: integer): nil
 ---@field disconnect fun(): boolean
@@ -49,7 +50,7 @@ local M = {
 ---@alias DotnetPipeMethod
 ---| "initialize"
 ---| "msbuild/build"
----| "msbuild/restore"
+---| "nuget/restore"
 ---| "msbuild/pack"
 ---| "user-secrets/init"
 ---| "msbuild/query-properties"
@@ -254,6 +255,29 @@ function M:request_enumerate(method, params, on_yield, on_finished, on_error)
       error("Response was not an enumerable")
     end
   end)
+end
+
+function M:request_property_enumerate(token, on_yield, on_finished, on_error)
+  local all_results = {}
+
+  local function handle_next(token)
+    self._enumerable_next(token, function(res)
+      if res.error and on_error then on_error(res) end
+      if res.result then
+        if #res.result.values > 0 then
+          vim.list_extend(all_results, res.result.values)
+          if on_yield then on_yield(res.result.values) end
+        end
+        if res.result.finished == false then
+          handle_next(token)
+        else
+          if on_finished then on_finished(all_results) end
+        end
+      end
+    end)
+  end
+
+  handle_next(token)
 end
 
 function M.cancel(id)


### PR DESCRIPTION
Helps with recieving large responses like build errors and build warnings. Lets you enumerate arbitrary properties within rpc response