### PR TITLE
feat: add workspace diagnostics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 - User Secrets Management: Edit, create, and preview .NET user secrets directly within Neovim.
 - Debugging Helpers: While easy-dotnet.nvim doesn't set up DAP (Debugger Adapter Protocol) for you, it provides useful helper functions for debugging. These include resolving the DLL you are debugging and rebuilding before launching DAP, ensuring a smooth debugging experience.
 - Test runner: Test runner similiar to the one you find in Rider.
+- Workspace diagnostics: Get diagnostic errors and warnings from your entire solution or individual projects
 - Outdated command: Makes checking outdated packages a breeze using virtual text
 - (csproj/fsproj) mappings: Keymappings for .csproj and .fsproj files are automatically available
 - Auto bootstrap namespace: Automatically inserts namespace and class/interface when opening a newly created `.cs` file. (also checks clipboard for json to create class from)
@@ -340,6 +341,8 @@ require("lualine").setup {
 | `dotnet.get_debug_dll()`                      | Returns the DLL from the `bin/debug` folder                                                                 |
 | `dotnet.get_environment_variables(project_name, project_path, use_default_launch_profile: boolean)` | Returns the environment variables from the `launchSetting.json` file                                         |
 | `dotnet.reset()`                              | Deletes all files persisted by `easy-dotnet.nvim`. Use this if unable to pick a different solution or project |
+||
+| `dotnet.diagnostics.get_workspace_diagnostics(severity_filter)` | Get workspace diagnostics for errors or warnings. Severity filter can be `"error"` or `"warning"` |
 
 ```lua
 local dotnet = require("easy-dotnet")
@@ -430,6 +433,8 @@ Dotnet solution select
 Dotnet solution add
 Dotnet solution remove
 Dotnet outdated
+Dotnet diagnostics error
+Dotnet diagnostics warning  -- Shows both warnings and errors
 checkhealth easy-dotnet
 
 -- Internal 

--- a/README.md
+++ b/README.md
@@ -45,29 +45,33 @@ As a developer transitioning from Rider to Neovim, I found myself missing the si
 9. [Project view](#project-view)
    - [Features](#features-1)
    - [Keymaps](#keymaps-1)
-10. [Outdated](#outdated)
+10. [Workspace Diagnostics](#workspace-diagnostics)
+    - [Commands](#commands-1)
+    - [Configuration](#configuration)
+    - [Features](#features-2)
+11. [Outdated](#outdated)
     - [Requirements](#requirements-1)
-11. [Add](#add)
+12. [Add](#add)
     - [Add package](#add-package)
-12. [Project mappings](#project-mappings)
+13. [Project mappings](#project-mappings)
     - [Add reference](#add-reference)
     - [Package autocomplete](#package-autocomplete)
-13. [New](#new)
+14. [New](#new)
     - [Project](#project)
     - [Configuration file](#configuration-file)
     - [Integrating with nvim-tree](#integrating-with-nvim-tree)
     - [Integrating with neo-tree](#integrating-with-neo-tree)
     - [Integrating with mini.files](#integrating-with-mini-files)
     - [Integrating with snacks.explorer](#integrating-with-snacks-explorer)
-14. [EntityFramework](#entityframework)
+15. [EntityFramework](#entityframework)
     - [Database](#database)
     - [Migrations](#migrations)
-15. [Language injections](#language-injections)
+16. [Language injections](#language-injections)
     - [Showcase](#showcase)
     - [Requirements](#requirements-2)
     - [Support matrix](#support-matrix)
-16. [Nvim-dap configuration](#nvim-dap-configuration)
-17. [Troubleshooting](#troubleshooting)
+17. [Nvim-dap configuration](#nvim-dap-configuration)
+18. [Troubleshooting](#troubleshooting)
 
 ## Features
 
@@ -244,7 +248,11 @@ Although not *required* by the plugin, it is highly recommended to install one o
         mappings = {
           open_variable_viewer = { lhs = "T", desc = "open variable viewer" },
         },
-      }
+      },
+      diagnostics = {
+        default_severity = "error",
+        setqflist = false,
+      },
     })
 
     -- Example command
@@ -342,7 +350,9 @@ require("lualine").setup {
 | `dotnet.get_environment_variables(project_name, project_path, use_default_launch_profile: boolean)` | Returns the environment variables from the `launchSetting.json` file                                         |
 | `dotnet.reset()`                              | Deletes all files persisted by `easy-dotnet.nvim`. Use this if unable to pick a different solution or project |
 ||
-| `dotnet.diagnostics.get_workspace_diagnostics(severity_filter)` | Get workspace diagnostics for errors or warnings. Severity filter can be `"error"` or `"warning"` |
+| `diagnostics.get_workspace_diagnostics()`     | Get workspace diagnostics using configured default severity                                                 |
+| `diagnostics.get_workspace_diagnostics("error")` | Get workspace diagnostics for errors only                                                                |
+| `diagnostics.get_workspace_diagnostics("warning")` | Get workspace diagnostics for errors and warnings                                                       |
 
 ```lua
 local dotnet = require("easy-dotnet")
@@ -386,7 +396,12 @@ dotnet.watch()
 dotnet.watch_default()
 dotnet.secrets()                                                          
 dotnet.clean()                                                           
-dotnet.restore()                   
+dotnet.restore()
+
+local diagnostics = require("easy-dotnet.actions.diagnostics")
+diagnostics.get_workspace_diagnostics()
+diagnostics.get_workspace_diagnostics("error") 
+diagnostics.get_workspace_diagnostics("warning")
 ```
 
 ### Vim commands
@@ -433,8 +448,9 @@ Dotnet solution select
 Dotnet solution add
 Dotnet solution remove
 Dotnet outdated
-Dotnet diagnostics error
-Dotnet diagnostics warning  -- Shows both warnings and errors
+Dotnet diagnostic
+Dotnet diagnostic errors
+Dotnet diagnostic warnings
 checkhealth easy-dotnet
 
 -- Internal 
@@ -535,6 +551,40 @@ Keymaps are region-specific and work based on context (e.g., when hovering over 
 - `a`: Add package reference.
 - `r`: Remove package reference.
 - `<C-b>`: View package in browser.
+
+## Workspace Diagnostics
+
+Analyze your entire solution or individual projects for compilation errors and warnings using Roslyn diagnostics.
+
+### Commands
+
+- `Dotnet diagnostic` - Uses the configured default severity (errors by default)
+- `Dotnet diagnostic errors` - Shows only compilation errors  
+- `Dotnet diagnostic warnings` - Shows both errors and warnings
+
+### Configuration
+
+```lua
+require("easy-dotnet").setup({
+  diagnostics = {
+    default_severity = "error",  -- "error" or "warning" (default: "error")
+    setqflist = false,           -- Populate quickfix list automatically (default: false)
+  },
+})
+```
+
+### Features
+
+- **Solution/Project Selection**: When multiple projects or solutions are available, you'll be prompted to select which one to analyze
+- **Roslyn Integration**: Uses the Roslyn Language Server Protocol for accurate diagnostics
+- **Neovim Diagnostics Integration**: Results are populated into Neovim's built-in diagnostic system, allowing you to:
+  - Navigate between diagnostics using `:lua vim.diagnostic.goto_next()` and `:lua vim.diagnostic.goto_prev()`
+  - View diagnostics in the quickfix list using `:lua vim.diagnostic.setqflist()` (or automatically if configured)
+  - See inline diagnostic messages
+  - View with trouble (requires [trouble.nvim](https://github.com/folke/trouble.nvim))
+  - View with snacks diagnostic picker (requires [snacks.nvim](https://github.com/folke/snacks.nvim))
+
+The diagnostics will appear in Neovim's diagnostic system, allowing you to navigate through them using your standard diagnostic keymaps. If you have trouble.nvim or snacks.nvim configured, the diagnostics will automatically be available in their respective interfaces.
 
 ## Outdated
 

--- a/lua/easy-dotnet/actions/diagnostics.lua
+++ b/lua/easy-dotnet/actions/diagnostics.lua
@@ -40,19 +40,20 @@ function M.get_workspace_diagnostics(severity_filter)
 
     local all_items = {}
 
-    for _, project in ipairs(projects) do
-      table.insert(all_items, {
-        display = "Project: " .. vim.fn.fnamemodify(project, ":t"),
-        value = project,
-        type = "project",
-      })
-    end
-
+    -- Add solutions first to prioritize them in the picker
     for _, solution in ipairs(solutions) do
       table.insert(all_items, {
         display = "Solution: " .. vim.fn.fnamemodify(solution, ":t"),
         value = solution,
         type = "solution",
+      })
+    end
+
+    for _, project in ipairs(projects) do
+      table.insert(all_items, {
+        display = "Project: " .. vim.fn.fnamemodify(project, ":t"),
+        value = project,
+        type = "project",
       })
     end
 

--- a/lua/easy-dotnet/actions/diagnostics.lua
+++ b/lua/easy-dotnet/actions/diagnostics.lua
@@ -5,9 +5,7 @@ local diagnostics = require("easy-dotnet.diagnostics")
 local parsers = require("easy-dotnet.parsers")
 
 local function get_default_filter()
-  return function(filename)
-    return (filename:match("%.cs$") or filename:match("%.fs$")) and not filename:match("/obj/") and not filename:match("/bin/")
-  end
+  return function(filename) return (filename:match("%.cs$") or filename:match("%.fs$")) and not filename:match("/obj/") and not filename:match("/bin/") end
 end
 
 ---@param severity_filter "error"|"warning"
@@ -22,55 +20,47 @@ local function get_severity_params(severity_filter)
 end
 
 local function execute_diagnostics_request(selected_item, include_warnings)
-  rpc.global_rpc_client:get_workspace_diagnostics(
-    selected_item.value,
-    include_warnings,
-    function(response)
-      diagnostics.populate_diagnostics(response, get_default_filter())
-    end
-  )
+  rpc.global_rpc_client:get_workspace_diagnostics(selected_item.value, include_warnings, function(response) diagnostics.populate_diagnostics(response, get_default_filter()) end)
 end
 
 ---@param severity_filter "error"|"warning"
 function M.get_workspace_diagnostics(severity_filter)
   local include_warnings = get_severity_params(severity_filter)
-  
+
   rpc.global_rpc_client:initialize(function()
     local projects = parsers.sln_parser.find_project_files()
     local solutions = parsers.sln_parser.get_solutions()
-    
+
     local all_items = {}
-    
+
     for _, project in ipairs(projects) do
       table.insert(all_items, {
         display = "Project: " .. vim.fn.fnamemodify(project, ":t"),
         value = project,
-        type = "project"
+        type = "project",
       })
     end
-    
+
     for _, solution in ipairs(solutions) do
       table.insert(all_items, {
         display = "Solution: " .. vim.fn.fnamemodify(solution, ":t"),
         value = solution,
-        type = "solution"
+        type = "solution",
       })
     end
-    
+
     if #all_items == 0 then
       vim.notify("No .csproj or .sln files found in the workspace", vim.log.levels.WARN)
       return
     end
-    
+
     if #all_items == 1 then
       local selected = all_items[1]
       execute_diagnostics_request(selected, include_warnings)
     else
       local picker = require("easy-dotnet.picker")
       picker.picker(nil, all_items, function(selected)
-        if selected then
-          execute_diagnostics_request(selected, include_warnings)
-        end
+        if selected then execute_diagnostics_request(selected, include_warnings) end
       end, "Select project or solution for diagnostics:")
     end
   end)

--- a/lua/easy-dotnet/actions/diagnostics.lua
+++ b/lua/easy-dotnet/actions/diagnostics.lua
@@ -20,11 +20,18 @@ local function get_severity_params(severity_filter)
 end
 
 local function execute_diagnostics_request(selected_item, include_warnings)
+  if not selected_item or not selected_item.value or selected_item.value == "" then
+    vim.notify("Invalid project/solution path", vim.log.levels.ERROR)
+    return
+  end
   rpc.global_rpc_client:get_workspace_diagnostics(selected_item.value, include_warnings, function(response) diagnostics.populate_diagnostics(response, get_default_filter()) end)
 end
 
----@param severity_filter "error"|"warning"
+---@param severity_filter? "error"|"warning"
 function M.get_workspace_diagnostics(severity_filter)
+  -- Use configured default if no severity filter is provided
+  if not severity_filter then severity_filter = require("easy-dotnet.options").options.diagnostics.default_severity end
+
   local include_warnings = get_severity_params(severity_filter)
 
   rpc.global_rpc_client:initialize(function()

--- a/lua/easy-dotnet/actions/diagnostics.lua
+++ b/lua/easy-dotnet/actions/diagnostics.lua
@@ -1,0 +1,79 @@
+local M = {}
+
+local rpc = require("easy-dotnet.rpc.rpc")
+local diagnostics = require("easy-dotnet.diagnostics")
+local parsers = require("easy-dotnet.parsers")
+
+local function get_default_filter()
+  return function(filename)
+    return (filename:match("%.cs$") or filename:match("%.fs$")) and not filename:match("/obj/") and not filename:match("/bin/")
+  end
+end
+
+---@param severity_filter "error"|"warning"
+local function get_severity_params(severity_filter)
+  if severity_filter == "error" then
+    return false
+  elseif severity_filter == "warning" then
+    return true
+  else
+    error("Invalid severity filter: " .. tostring(severity_filter))
+  end
+end
+
+local function execute_diagnostics_request(selected_item, include_warnings)
+  rpc.global_rpc_client:get_workspace_diagnostics(
+    selected_item.value,
+    include_warnings,
+    function(response)
+      diagnostics.populate_diagnostics(response, get_default_filter())
+    end
+  )
+end
+
+---@param severity_filter "error"|"warning"
+function M.get_workspace_diagnostics(severity_filter)
+  local include_warnings = get_severity_params(severity_filter)
+  
+  rpc.global_rpc_client:initialize(function()
+    local projects = parsers.sln_parser.find_project_files()
+    local solutions = parsers.sln_parser.get_solutions()
+    
+    local all_items = {}
+    
+    for _, project in ipairs(projects) do
+      table.insert(all_items, {
+        display = "Project: " .. vim.fn.fnamemodify(project, ":t"),
+        value = project,
+        type = "project"
+      })
+    end
+    
+    for _, solution in ipairs(solutions) do
+      table.insert(all_items, {
+        display = "Solution: " .. vim.fn.fnamemodify(solution, ":t"),
+        value = solution,
+        type = "solution"
+      })
+    end
+    
+    if #all_items == 0 then
+      vim.notify("No .csproj or .sln files found in the workspace", vim.log.levels.WARN)
+      return
+    end
+    
+    if #all_items == 1 then
+      local selected = all_items[1]
+      execute_diagnostics_request(selected, include_warnings)
+    else
+      local picker = require("easy-dotnet.picker")
+      picker.picker(nil, all_items, function(selected)
+        if selected then
+          execute_diagnostics_request(selected, include_warnings)
+        end
+      end, "Select project or solution for diagnostics:")
+    end
+  end)
+end
+
+return M

--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -368,12 +368,12 @@ M._server = {
 }
 
 M.diagnostic = {
-  handle = nil,
+  handle = function() require("easy-dotnet.actions.diagnostics").get_workspace_diagnostics() end,
   subcommands = {
-    error = {
+    errors = {
       handle = function() require("easy-dotnet.actions.diagnostics").get_workspace_diagnostics("error") end,
     },
-    warning = {
+    warnings = {
       handle = function() require("easy-dotnet.actions.diagnostics").get_workspace_diagnostics("warning") end,
     },
   },

--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -367,4 +367,16 @@ M._server = {
   },
 }
 
+M.diagnostic = {
+  handle = nil,
+  subcommands = {
+    error = {
+      handle = function() require("easy-dotnet.actions.diagnostics").get_workspace_diagnostics("error") end,
+    },
+    warning = {
+      handle = function() require("easy-dotnet.actions.diagnostics").get_workspace_diagnostics("warning") end,
+    },
+  },
+}
+
 return M

--- a/lua/easy-dotnet/diagnostics.lua
+++ b/lua/easy-dotnet/diagnostics.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local diagnostic_ns = vim.api.nvim_create_namespace("easy-dotnet-diagnostics")
 
-
 local function get_or_create_buffer(filename)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_get_name(buf) == filename then return buf end
@@ -45,7 +44,6 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
     return
   end
 
-
   local roslyn_clients = vim.lsp.get_clients({ name = "roslyn" })
   local ns = diagnostic_ns
 
@@ -79,6 +77,9 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
   local total_count = #diagnostics
   local filtered_count = vim.tbl_count(grouped_diagnostics)
   vim.notify(string.format("Populated %d diagnostics across %d files", total_count, filtered_count), vim.log.levels.INFO)
+
+  local options = require("easy-dotnet.options").options
+  if options.diagnostics and options.diagnostics.setqflist then vim.diagnostic.setqflist() end
 end
 
 return M

--- a/lua/easy-dotnet/diagnostics.lua
+++ b/lua/easy-dotnet/diagnostics.lua
@@ -2,27 +2,6 @@ local M = {}
 
 local diagnostic_ns = vim.api.nvim_create_namespace("easy-dotnet-diagnostics")
 
-local autocmd_setup = false
-local function setup_lsp_integration()
-  if autocmd_setup then return end
-  autocmd_setup = true
-
-  vim.api.nvim_create_autocmd({ "LspAttach", "InsertLeave" }, {
-    group = vim.api.nvim_create_augroup("easy-dotnet-diagnostics-lsp", { clear = true }),
-    pattern = { "*.cs", "*.fs" },
-    callback = function()
-      vim.defer_fn(function()
-        local clients = vim.lsp.get_clients({ name = "roslyn" })
-        if not clients or #clients == 0 then return end
-
-        local buffers = vim.lsp.get_buffers_by_client_id(clients[1].id)
-        for _, buf in ipairs(buffers) do
-          vim.lsp.util._refresh("textDocument/diagnostic", { bufnr = buf })
-        end
-      end, 100)
-    end,
-  })
-end
 
 local function get_or_create_buffer(filename)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -66,7 +45,6 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
     return
   end
 
-  setup_lsp_integration()
 
   local roslyn_clients = vim.lsp.get_clients({ name = "roslyn" })
   local ns = diagnostic_ns

--- a/lua/easy-dotnet/diagnostics.lua
+++ b/lua/easy-dotnet/diagnostics.lua
@@ -1,0 +1,112 @@
+local M = {}
+
+local diagnostic_ns = vim.api.nvim_create_namespace("easy-dotnet-diagnostics")
+
+local autocmd_setup = false
+local function setup_lsp_integration()
+  if autocmd_setup then return end
+  autocmd_setup = true
+  
+  vim.api.nvim_create_autocmd({ "LspAttach", "InsertLeave" }, {
+    group = vim.api.nvim_create_augroup("easy-dotnet-diagnostics-lsp", { clear = true }),
+    pattern = { "*.cs", "*.fs" },
+    callback = function()
+      vim.defer_fn(function()
+        local clients = vim.lsp.get_clients({ name = "roslyn" })
+        if not clients or #clients == 0 then return end
+
+        local buffers = vim.lsp.get_buffers_by_client_id(clients[1].id)
+        for _, buf in ipairs(buffers) do
+          vim.lsp.util._refresh("textDocument/diagnostic", { bufnr = buf })
+        end
+      end, 100)
+    end,
+  })
+end
+
+local function get_or_create_buffer(filename)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_get_name(buf) == filename then return buf end
+  end
+  
+  if vim.fn.filereadable(filename) == 1 then
+    return vim.fn.bufadd(filename)
+  end
+  
+  return nil
+end
+
+---@param diagnostic_msg table DiagnosticMessage from server
+---@return vim.Diagnostic
+local function diagnostic_message_to_vim(diagnostic_msg)
+  return {
+    lnum = diagnostic_msg.range.start.line,
+    col = diagnostic_msg.range.start.character,
+    end_lnum = diagnostic_msg.range["end"].line,
+    end_col = diagnostic_msg.range["end"].character,
+    severity = diagnostic_msg.severity,
+    message = diagnostic_msg.message,
+    source = diagnostic_msg.source or "roslyn",
+    code = diagnostic_msg.code,
+    user_data = {
+      category = diagnostic_msg.category
+    }
+  }
+end
+
+---@param diagnostics_response table 
+---@param filter_func? function Optional function to filter files
+function M.populate_diagnostics(diagnostics_response, filter_func)
+  if not diagnostics_response then
+    vim.notify("No diagnostics response received", vim.log.levels.WARN)
+    return
+  end
+  
+  local diagnostics = diagnostics_response
+  if type(diagnostics) ~= "table" then
+    vim.notify("Invalid diagnostics response format", vim.log.levels.WARN)
+    return
+  end
+
+  setup_lsp_integration()
+  
+  local roslyn_clients = vim.lsp.get_clients({ name = "roslyn" })
+  local ns = diagnostic_ns
+  
+  if roslyn_clients and #roslyn_clients > 0 then
+    for _, client in ipairs(roslyn_clients) do
+      local ok, lsp_ns = pcall(vim.lsp.diagnostic.get_namespace, client.id)
+      if ok and lsp_ns then
+        ns = lsp_ns
+        break
+      end
+    end
+  end
+
+  vim.diagnostic.reset(ns)
+  
+  local grouped_diagnostics = {}
+  for _, diagnostic in ipairs(diagnostics) do
+    local filepath = diagnostic.filePath
+    
+    if not filter_func or filter_func(filepath) then
+      if not grouped_diagnostics[filepath] then
+        grouped_diagnostics[filepath] = {}
+      end
+      table.insert(grouped_diagnostics[filepath], diagnostic_message_to_vim(diagnostic))
+    end
+  end
+  
+  for filepath, file_diagnostics in pairs(grouped_diagnostics) do
+    local buf = get_or_create_buffer(filepath)
+    if buf then
+      vim.diagnostic.set(ns, buf, file_diagnostics)
+    end
+  end
+  
+  local total_count = #diagnostics
+  local filtered_count = vim.tbl_count(grouped_diagnostics)
+  vim.notify(string.format("Populated %d diagnostics across %d files", total_count, filtered_count), vim.log.levels.INFO)
+end
+
+return M

--- a/lua/easy-dotnet/diagnostics.lua
+++ b/lua/easy-dotnet/diagnostics.lua
@@ -6,7 +6,7 @@ local autocmd_setup = false
 local function setup_lsp_integration()
   if autocmd_setup then return end
   autocmd_setup = true
-  
+
   vim.api.nvim_create_autocmd({ "LspAttach", "InsertLeave" }, {
     group = vim.api.nvim_create_augroup("easy-dotnet-diagnostics-lsp", { clear = true }),
     pattern = { "*.cs", "*.fs" },
@@ -28,11 +28,9 @@ local function get_or_create_buffer(filename)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_get_name(buf) == filename then return buf end
   end
-  
-  if vim.fn.filereadable(filename) == 1 then
-    return vim.fn.bufadd(filename)
-  end
-  
+
+  if vim.fn.filereadable(filename) == 1 then return vim.fn.bufadd(filename) end
+
   return nil
 end
 
@@ -49,19 +47,19 @@ local function diagnostic_message_to_vim(diagnostic_msg)
     source = diagnostic_msg.source or "roslyn",
     code = diagnostic_msg.code,
     user_data = {
-      category = diagnostic_msg.category
-    }
+      category = diagnostic_msg.category,
+    },
   }
 end
 
----@param diagnostics_response table 
+---@param diagnostics_response table
 ---@param filter_func? function Optional function to filter files
 function M.populate_diagnostics(diagnostics_response, filter_func)
   if not diagnostics_response then
     vim.notify("No diagnostics response received", vim.log.levels.WARN)
     return
   end
-  
+
   local diagnostics = diagnostics_response
   if type(diagnostics) ~= "table" then
     vim.notify("Invalid diagnostics response format", vim.log.levels.WARN)
@@ -69,10 +67,10 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
   end
 
   setup_lsp_integration()
-  
+
   local roslyn_clients = vim.lsp.get_clients({ name = "roslyn" })
   local ns = diagnostic_ns
-  
+
   if roslyn_clients and #roslyn_clients > 0 then
     for _, client in ipairs(roslyn_clients) do
       local ok, lsp_ns = pcall(vim.lsp.diagnostic.get_namespace, client.id)
@@ -84,26 +82,22 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
   end
 
   vim.diagnostic.reset(ns)
-  
+
   local grouped_diagnostics = {}
   for _, diagnostic in ipairs(diagnostics) do
     local filepath = diagnostic.filePath
-    
+
     if not filter_func or filter_func(filepath) then
-      if not grouped_diagnostics[filepath] then
-        grouped_diagnostics[filepath] = {}
-      end
+      if not grouped_diagnostics[filepath] then grouped_diagnostics[filepath] = {} end
       table.insert(grouped_diagnostics[filepath], diagnostic_message_to_vim(diagnostic))
     end
   end
-  
+
   for filepath, file_diagnostics in pairs(grouped_diagnostics) do
     local buf = get_or_create_buffer(filepath)
-    if buf then
-      vim.diagnostic.set(ns, buf, file_diagnostics)
-    end
+    if buf then vim.diagnostic.set(ns, buf, file_diagnostics) end
   end
-  
+
   local total_count = #diagnostics
   local filtered_count = vim.tbl_count(grouped_diagnostics)
   vim.notify(string.format("Populated %d diagnostics across %d files", total_count, filtered_count), vim.log.levels.INFO)

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -292,4 +292,6 @@ M.package_completion_source = require("easy-dotnet.csproj-mappings").package_com
 
 M.get_test_results = require("easy-dotnet.test-signs").get_test_results
 
+M.diagnostics = require("easy-dotnet.actions.diagnostics")
+
 return M

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -8,9 +8,14 @@ local polyfills = require("easy-dotnet.polyfills")
 ---@field enable_filetypes boolean
 ---@field picker PickerType
 ---@field notifications Notifications
+---@field diagnostics DiagnosticsOptions
 
 ---@class Notifications
 ---@field handler fun(start_event: JobEvent): fun(finished_event: JobEvent)
+
+---@class DiagnosticsOptions
+---@field default_severity "error" | "warning"
+---@field setqflist boolean
 
 ---@class TestRunnerIcons
 ---@field passed string
@@ -187,6 +192,10 @@ local M = {
       mappings = {
         open_variable_viewer = { lhs = "T", desc = "open variable viewer" },
       },
+    },
+    diagnostics = {
+      default_severity = "error",
+      setqflist = false,
     },
   },
 }

--- a/lua/easy-dotnet/rpc/dotnet-client.lua
+++ b/lua/easy-dotnet/rpc/dotnet-client.lua
@@ -525,7 +525,7 @@ function M:get_workspace_diagnostics(project_path, include_warnings, cb)
   local id = self._client:request_enumerate(
     "roslyn/get-workspace-diagnostics",
     {
-      projectPath = project_path,
+      targetPath = project_path,
       includeWarnings = include_warnings,
     },
     nil,

--- a/lua/easy-dotnet/rpc/dotnet-client.lua
+++ b/lua/easy-dotnet/rpc/dotnet-client.lua
@@ -516,23 +516,29 @@ function M:template_instantiate(identity, name, output_path, params, cb)
 end
 
 function M:get_workspace_diagnostics(project_path, include_warnings, cb)
-  local finished = jobs.register_job({ 
-    name = "Getting workspace diagnostics...", 
-    on_error_text = "Failed to get diagnostics", 
-    on_success_text = "Diagnostics retrieved" 
+  local finished = jobs.register_job({
+    name = "Getting workspace diagnostics...",
+    on_error_text = "Failed to get diagnostics",
+    on_success_text = "Diagnostics retrieved",
   })
-  
-  local id = self._client:request_enumerate("roslyn/get-workspace-diagnostics", { 
-    projectPath = project_path, 
-    includeWarnings = include_warnings
-  }, nil, function(response)
-    finished(true)
-    if cb then cb(response) end
-  end, function(error_response)
-    handle_rpc_error(error_response)
-    finished(false)
-  end)
-  
+
+  local id = self._client:request_enumerate(
+    "roslyn/get-workspace-diagnostics",
+    {
+      projectPath = project_path,
+      includeWarnings = include_warnings,
+    },
+    nil,
+    function(response)
+      finished(true)
+      if cb then cb(response) end
+    end,
+    function(error_response)
+      handle_rpc_error(error_response)
+      finished(false)
+    end
+  )
+
   return id
 end
 


### PR DESCRIPTION
  Add workspace diagnostics functionality to get compilation
  errors and warnings from entire solutions or individual projects.

  - Add Dotnet diagnostic error/warning commands
  - Integrate with Roslyn LSP for cross-file diagnostic refresh
  - Populate diagnostics into Neovim's diagnostic system
  - Support both project and solution-level analysis

  Commands:
  - Dotnet diagnostic error (errors only)
  - Dotnet diagnostic warning (errors + warnings)

  API: dotnet.diagnostics.get_workspace_diagnostics(severity_filter)

Depends on GustavEikaas/easy-dotnet-server#92

