### PR TITLE
fix(rpc): hanging jobs when server fails

### DIFF
--- a/lua/easy-dotnet/parsers/sln-parse.lua
+++ b/lua/easy-dotnet/parsers/sln-parse.lua
@@ -148,13 +148,9 @@ local function preload_msbuild_async_or_sync(project_lines, solution_file_path)
   local co = coroutine.running()
   local remaining = #project_lines
 
-  local jobs = require("easy-dotnet.ui-modules.jobs")
   for _, proj_path in ipairs(project_lines) do
     local project_file_path = generate_absolute_path_for_project(proj_path, solution_file_path)
-    local proj_name = vim.fn.fnamemodify(project_file_path, ":t:r")
-    local on_finished = jobs.register_job({ name = "Loading " .. proj_name, on_success_text = proj_name .. " loaded", on_error_text = "Failed to load " .. proj_name })
     require("easy-dotnet.parsers.csproj-parse").preload_msbuild_properties(project_file_path, function()
-      on_finished(true)
       remaining = remaining - 1
       if remaining == 0 then
         if co then coroutine.resume(co) end

--- a/lua/easy-dotnet/rpc/rpc-client.lua
+++ b/lua/easy-dotnet/rpc/rpc-client.lua
@@ -53,7 +53,7 @@ local M = {
 ---| "nuget/restore"
 ---| "msbuild/pack"
 ---| "user-secrets/init"
----| "msbuild/query-properties"
+---| "msbuild/project-properties"
 ---| "msbuild/add-package-reference"
 ---| "solution/list-projects"
 ---| "nuget/push"


### PR DESCRIPTION
When server fails for whatever reason some jobs just hang indefinitely. Like query project properties and initializing. This PR fixes that