### PR TITLE
fix: handle test errorMessage as table

### DIFF
--- a/lua/easy-dotnet/test-runner/keymaps.lua
+++ b/lua/easy-dotnet/test-runner/keymaps.lua
@@ -35,7 +35,7 @@ local function parse_status(result, test_line, options)
   elseif result.outcome == "failed" or result.outcome == "error" then
     test_line.icon = options.icons.failed
 
-    if result.errorMessage or result.stackTrace then test_line.expand = vim.list_extend({ result.errorMessage or "" }, result.stackTrace or {}) end
+    if result.errorMessage or result.stackTrace then test_line.expand = vim.list_extend(result.errorMessage or {}, result.stackTrace or {}) end
   elseif result.outcome == "skipped" then
     test_line.icon = options.icons.skipped
   else


### PR DESCRIPTION
Currently opening stack trace with test result fails since `errorMessage` contains new line characters and `nvim_buf_set_lines` does not allow it.

Related: BE change https://github.com/GustavEikaas/easy-dotnet-server/pull/113

