### PR TITLE
fix: cleanup cancelled jobs

### DIFF
--- a/lua/easy-dotnet/csproj-mappings.lua
+++ b/lua/easy-dotnet/csproj-mappings.lua
@@ -1,6 +1,6 @@
 local M = {
-  include_pending = nil,
-  version_pending = nil,
+  include_pending_cancel_cb = nil,
+  version_pending_cancel_cb = nil,
 }
 
 local picker = require("easy-dotnet.picker")
@@ -78,25 +78,27 @@ M.package_completion_cmp = {
 
     if inside_include then
       local search_term = inside_include:gsub('%Include="', "")
-      if M.include_pending then
-        client._client.cancel(M.include_pending)
-        M.include_pending = nil
+      if M.include_pending_cancel_cb then
+        M.include_pending_cancel_cb()
+        M.include_pending_cancel_cb = nil
       end
       client:initialize(function()
-        M.include_pending = client.nuget:nuget_search(search_term, nil, function(res)
-          local items = polyfills.tbl_map(function(value) return { label = value.id, kind = 18 } end, res)
-          callback({ items = items, isIncomplete = true })
-        end).id
+        M.include_pending_cancel_cb = client.nuget
+          :nuget_search(search_term, nil, function(res)
+            local items = polyfills.tbl_map(function(value) return { label = value.id, kind = 18 } end, res)
+            callback({ items = items, isIncomplete = true })
+          end)
+          .cancel()
       end)
     elseif inside_version then
       local package_name = current_line:match('Include="([^"]+)"')
 
-      if M.version_pending then
-        client._client.cancel(M.version_pending)
-        M.version_pending = nil
+      if M.version_pending_cancel_cb then
+        M.version_pending_cancel_cb()
+        M.version_pending_cancel_cb = nil
       end
       client:initialize(function()
-        M.version_pending = client.nuget:nuget_get_package_versions(package_name, nil, false, function(res)
+        M.version_pending_cancel_cb = client.nuget:nuget_get_package_versions(package_name, nil, false, function(res)
           local index = 0
           local latest = nil
           local last_index = #res - 1
@@ -119,7 +121,7 @@ M.package_completion_cmp = {
             preselect = true,
           }) end
           callback({ items = items, isIncomplete = false })
-        end).id
+        end).cancel
       end)
     end
   end,

--- a/lua/easy-dotnet/rpc/dotnet-client.lua
+++ b/lua/easy-dotnet/rpc/dotnet-client.lua
@@ -95,7 +95,13 @@ function M.create_enumerate_rpc_call(opts)
     if not id then error("Failed to send RPC call") end
     return {
       id = id,
-      cancel = function() opts.client.cancel(id) end,
+      cancel = function()
+        opts.client.cancel(id)
+        if maybe_job then
+          vim.print("Cleaning up cancelled job")
+          maybe_job(true)
+        end
+      end,
     }
   end
 end


### PR DESCRIPTION
When searching for nuget packages/nuget package versions it would automatically cancel in-flight requests limiting concurrency to 1. client code did not cleanup the jobs that were being cancelled causing them to pile up and spin forever