### PR TITLE
feat(rpc): add openBuffer client method

### DIFF
--- a/lua/easy-dotnet/rpc/rpc-client.lua
+++ b/lua/easy-dotnet/rpc/rpc-client.lua
@@ -179,7 +179,7 @@ local function handle_response(decoded)
     vim.schedule(function() cb(decoded) end)
   elseif vim.list_contains(client_methods, decoded.method) then
     vim.schedule(function() handle_server_request(decoded, make_response(decoded)) end)
-  -- else
+    -- else
     --TODO: want to warn user but also ignore cancelled requests.
   end
 end


### PR DESCRIPTION
Allows the server to request `openBuffer` with a path as argument. Client responds true if buffer was opened. 