### PR TITLE
fix: reverse backslash on *nix during nuget push

### DIFF
--- a/lua/easy-dotnet/actions/pack.lua
+++ b/lua/easy-dotnet/actions/pack.lua
@@ -71,6 +71,7 @@ local function push_nuget_package(project, configuration, source)
   if not ok or not props then error("Failed to parse MSBuild JSON output") end
 
   local out_dir = vim.fs.normalize(props.Properties.PackageOutputPath)
+  --TODO: vim.fs.normalize does not normalize \\ on unix. (fix when using easy-dotnet-server)
   if not require("easy-dotnet.extensions").isWindows() then out_dir = string.gsub(out_dir, "\\", "/") end
 
   local id = props.Properties.PackageId


### PR DESCRIPTION
Uses the existing extensions.lua to check for not Windows. If so, a `string.gsub(...)` is used to change back slashes into forward slashes. I only tested this for "bin\release". I also don't do a lot of Lua. I believe string.gsub(...) replaces all occurrences. 

If there is a function available for normalizing file paths that would fit better, let me know :). I did not see one. I can create one under a utils module and use it if that'd be preferred.