### PR TITLE
chore: deprecate `get_secrets_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,20 +124,6 @@ Although not *required* by the plugin, it is highly recommended to install one o
   -- are highly recommended for a better experience
   dependencies = { "nvim-lua/plenary.nvim", 'nvim-telescope/telescope.nvim', },
   config = function()
-    local function get_secret_path(secret_guid)
-      local path = ""
-      local home_dir = vim.fn.expand('~')
-      if require("easy-dotnet.extensions").isWindows() then
-        local secret_path = home_dir ..
-            '\\AppData\\Roaming\\Microsoft\\UserSecrets\\' .. secret_guid .. "\\secrets.json"
-        path = secret_path
-      else
-        local secret_path = home_dir .. "/.microsoft/usersecrets/" .. secret_guid .. "/secrets.json"
-        path = secret_path
-      end
-      return path
-    end
-
     local dotnet = require("easy-dotnet")
     -- Options are not required
     dotnet.setup({
@@ -216,9 +202,6 @@ Although not *required* by the plugin, it is highly recommended to install one o
         vim.cmd("vsplit")
         vim.cmd("term " .. command)
       end,
-      secrets = {
-        path = get_secret_path
-      },
       csproj_mappings = true,
       fsproj_mappings = true,
       auto_bootstrap_namespace = {


### PR DESCRIPTION
get_secrets_path was made a long time ago before I knew it is a static known path. It should never be necessary. Starting by simply removing from readme