### PR TITLE
fix: fixes find files not going up directory tree to find all slns

### DIFF
--- a/lua/easy-dotnet/roslyn/root_finder.lua
+++ b/lua/easy-dotnet/roslyn/root_finder.lua
@@ -38,9 +38,7 @@ local function find_files_in_directory_or_parents(directory, patterns)
       end
     end
 
-    if directory == cwd then
-      break
-    end
+    if directory == cwd then break end
 
     local parent = Path:new(directory):parent()
     if parent and parent:absolute() ~= directory then


### PR DESCRIPTION
find_files_in_directory_or_parents returned as soon as it found any matches, meaning that even if there were more
solutions to find, it stopped before it could find them.

this pr fixes the issue by scanning all the way up to cwd