### PR TITLE
feat(test-runner)!: set default viewmode to float

### DIFF
--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -97,7 +97,7 @@ local M = {
     },
     ---@type TestRunnerOptions
     test_runner = {
-      viewmode = "split",
+      viewmode = "float",
       vsplit_width = nil,
       vsplit_pos = nil,
       enable_buffer_test_execution = true,


### PR DESCRIPTION
I tried to install easy-dotnet.nvim in a scratch neovim config and the default viewmode of testrunner is terrible. 
This is technically a breaking change and im sorry but holy shit default viewmode is so much worse than float