### PR TITLE
Fix temp path on NixOs

### DIFF
--- a/lua/easy-dotnet/rpc/rpc.lua
+++ b/lua/easy-dotnet/rpc/rpc.lua
@@ -8,9 +8,7 @@ M.global_rpc_client = require("easy-dotnet.rpc.dotnet-client"):new()
 local function get_tmpdir()
   local tmp = os.getenv("TMPDIR") or os.getenv("TEMP") or os.getenv("TMP") or "/tmp"
   -- ensure trailing slash
-  if not tmp:match("/$") then
-    tmp = tmp .. "/"
-  end
+  if not tmp:match("/$") then tmp = tmp .. "/" end
   return tmp
 end
 


### PR DESCRIPTION
The client can not find a named pipe under nix-shell

because the real path is like
```
u_str LISTEN 0      4096      /tmp/nix-shell.wF6CCf/CoreFxPipe_EasyDotnet_pXLBvz2whUSepQ6NDwqiIw 98159995            * 0
u_str LISTEN 0      4096       /tmp/nix-shell.3pdhi1/CoreFxPipe_EasyDotnet_ROcrjwn9kiox3tKvRWcQg 98152690            * 0
```