### PR TITLE
Fix temp path resolve on NixOS

### DIFF
--- a/lua/easy-dotnet/rpc/rpc.lua
+++ b/lua/easy-dotnet/rpc/rpc.lua
@@ -4,21 +4,29 @@ local M = {}
 
 M.global_rpc_client = require("easy-dotnet.rpc.dotnet-client"):new()
 
+-- returns a temp dir path with a trailing slash
+local function get_tmpdir()
+  local tmp = os.getenv("TMPDIR") or os.getenv("TEMP") or os.getenv("TMP") or "/tmp"
+  -- ensure trailing slash
+  if not tmp:match("/$") then
+    tmp = tmp .. "/"
+  end
+  return tmp
+end
+
 --- Returns the full platform-specific path for a named pipe.
 ---
 --- On Windows, returns a named pipe path like `\\.\pipe\<pipe_name>`.
---- On macOS, returns a path under `$TMPDIR/CoreFxPipe_<pipe_name>`.
---- On Linux/other Unix, returns a path under `/tmp/CoreFxPipe_<pipe_name>`.
+--- On macOS/Linux/Unix, returns a path under `$TMPDIR/CoreFxPipe_<pipe_name>`,
+--- falling back to `/tmp/CoreFxPipe_<pipe_name>` if TMPDIR is not set.
 ---
 --- @param pipe_name string The name of the pipe.
 --- @return string The full path to the pipe on the current platform.
 function M.get_pipe_path(pipe_name)
   if extensions.isWindows() then
     return [[\\.\pipe\]] .. pipe_name
-  elseif extensions.isDarwin() then
-    return os.getenv("TMPDIR") .. "CoreFxPipe_" .. pipe_name
   else
-    return "/tmp/CoreFxPipe_" .. pipe_name
+    return get_tmpdir() .. "CoreFxPipe_" .. pipe_name
   end
 end
 


### PR DESCRIPTION
The client can not find a named pipe under nix-shell

because the real path is like
```
u_str LISTEN 0      4096      /tmp/nix-shell.wF6CCf/CoreFxPipe_EasyDotnet_pXLBvz2whUSepQ6NDwqiIw 98159995            * 0
u_str LISTEN 0      4096       /tmp/nix-shell.3pdhi1/CoreFxPipe_EasyDotnet_ROcrjwn9kiox3tKvRWcQg 98152690            * 0
```