### PR TITLE
Too many didChangeWatchedFiles causes solution loading timeout and perf issues

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -184,7 +184,6 @@ function M.enable(opts)
 
       local uri = vim.uri_from_fname(file)
       if type == "sln" then
-        print("LSP server cmd:", vim.inspect(client.config.cmd))
         M.state[client.id] = job.register_job({ name = "Opening solution", on_error_text = "Failed to open solution", on_success_text = "Workspace ready", timeout = 120000 })
         client:notify("solution/open", { solution = uri })
       elseif type == "csproj" then


### PR DESCRIPTION
While working with a large .NET solution (~100 .csproj projects), I noticed severe performance degradation and excessive file-watcher registration activity coming from Roslyn. As a temporary fix, the code changes work fine for me (just prompted by the cursor to "disable and ignore events from LSP like workspace/didChangeWatchedFiles" because I don’t know much about LSP in general or this project in particular).

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles

@Gustav-Eikaas fyi, please check whether this introduces any issues.

The MR is kind of a draft, but it works well for me.
