### PR TITLE
feat: add winfixbuf to testrunner

### DIFF
--- a/lua/easy-dotnet/test-runner/render.lua
+++ b/lua/easy-dotnet/test-runner/render.lua
@@ -365,6 +365,7 @@ function M.open(mode)
     if not M.buf then M.buf = vim.api.nvim_create_buf(false, true) end
     local win_opts = get_default_win_opts()
     M.win = vim.api.nvim_open_win(M.buf, true, win_opts)
+    vim.wo[M.win].winfixbuf = true
     vim.api.nvim_buf_set_option(M.buf, "bufhidden", "hide")
     return true
   elseif mode == "split" or mode == "vsplit" then

--- a/lua/easy-dotnet/test-runner/window.lua
+++ b/lua/easy-dotnet/test-runner/window.lua
@@ -100,6 +100,7 @@ end
 function Window:create()
   local win = vim.api.nvim_open_win(self.buf, true, self.opts)
   self.win = win
+  vim.wo[win].winfixbuf = true
 
   vim.keymap.set("n", "q", function() vim.api.nvim_win_close(self.win, true) end, { buffer = self.buf, noremap = true, silent = true })
 


### PR DESCRIPTION
Sometimes I accidentally trigger my `:bnext` keybind and the testrunner window switches to the next listed buffer. Which is not intended and annoying