### PR TITLE
fix: Needing to select a sln every time I open cs file when there are multiple slns

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -70,14 +70,10 @@ function M.find_project_or_solution(bufnr, cb)
     return
   end
 
-  require("easy-dotnet.picker").picker(
-    nil,
-    vim.tbl_map(function(value) return { display = value } end, sln),
-    function(r) cb(vim.fs.dirname(r.display)) end,
-    "Pick solution file to start Roslyn from",
-    true,
-    true
-  )
+  require("easy-dotnet.picker").picker(nil, vim.tbl_map(function(value) return { display = value } end, sln), function(r)
+    require("easy-dotnet.default-manager").set_default_solution(nil, r.display)
+    cb(vim.fs.dirname(r.display))
+  end, "Pick solution file to start Roslyn from", true, true)
 end
 
 function M.find_sln_or_csproj(dir)


### PR DESCRIPTION
I'm not 100% sure what's happening, but I think line 129 in lsp.lua, `root_dir = M.find_project_or_solution`,
is causing an issue. I think `find_project_or_solution` is being called every time I open a .cs file, and because I sometimes have multiple solutions, I'm prompted to pick one each time.

`find_project_or_solution` does seem to look at cached files, so I just added a line to add a cached file after picking one.

I'm not sure if that's the best solution. I see there are a lot of find_solutions type methods, should I be using one of those instead?