### PR TITLE
fix(test-solution): test solution

### DIFF
--- a/lua/easy-dotnet/actions/test.lua
+++ b/lua/easy-dotnet/actions/test.lua
@@ -132,9 +132,7 @@ M.run_test_picker = function(term, use_default, args)
   end
 end
 
-M.test_solution = function(term, args)
-  test_solution(args, term)
-end
+M.test_solution = function(term, args) test_solution(args, term) end
 
 M.test_watcher = function(icons)
   local dn = require("easy-dotnet.parsers").sln_parser


### PR DESCRIPTION
It was so that the solution could never be tested, because the `cmd` variable was never passed correctly.
I have created a local function, so it's always passed correctly.