### PR TITLE
bugfix: `debug_test_from_buffer` use `set_breakpoint` instead of toggle

### DIFF
--- a/lua/easy-dotnet/test-signs.lua
+++ b/lua/easy-dotnet/test-signs.lua
@@ -37,11 +37,8 @@ local function debug_test_from_buffer()
   local current_line = vim.api.nvim_win_get_cursor(0)[1]
   require("easy-dotnet.test-runner.render").traverse(nil, function(node)
     if (node.type == "test" or node.type == "test_group") and compare_paths(node.file_path, curr_file) and node.line_number - 1 == current_line then
-      --TODO: Investigate why netcoredbg wont work without reopening the buffer????
-      vim.cmd("bdelete")
-      vim.cmd("edit " .. node.file_path)
       vim.api.nvim_win_set_cursor(0, { node.line_number and (node.line_number - 1) or 0, 0 })
-      dap.toggle_breakpoint()
+      dap.set_breakpoint()
 
       local dap_configuration = {
         type = "coreclr",


### PR DESCRIPTION
Hello,
When debugging unit tests from buffers I've experienced an issue where some of my tabpages would get deleted.

Upon closer look I've spotted a `bufdelete` + `edit` in the relevant function. I've removed these calls and replaced `toggle_breakpoint` with `set_breakpoint`.

This fix addresses the TODO, netcoredbg should now hit the breakpoints consistently. My tabpages are also doing better.

Thank you 🙏🏻 