### PR TITLE
issues with large solution opening

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -215,9 +215,7 @@ function M.enable(opts)
                 :totable()
 
               -- If solution is already loaded, let registration through normally
-              if M.solution_loaded[client_id] then
-                -- Let it through, already filtered
-              else
+              if not M.solution_loaded[client_id] then
                 -- Cache the entire registration (will register in bulk on solution/open)
                 if not M.pending_watchers[client_id] then M.pending_watchers[client_id] = {} end
                 table.insert(M.pending_watchers[client_id], registration)


### PR DESCRIPTION
The Roslyn LSP is very chatty when opening a solution with many projects. It spams a large number of
`workspace/didChangeWatchedFiles` registrations, which causes Neovim to repeatedly register file
watchers. This leads to significant lag.

I tried a workaround where all watcher registrations are loaded in bulk after the solution has
finished opening.

ref nvim: https://github.com/neovim/neovim/blob/661455cc4757f3de524f7f47bccf0c46fe0bc586/runtime/lua/vim/lsp/client.lua#L967

