### PR TITLE
feat(roslyn) resolve misc files

### DIFF
--- a/lua/easy-dotnet/cs-mappings.lua
+++ b/lua/easy-dotnet/cs-mappings.lua
@@ -72,37 +72,12 @@ local function auto_bootstrap_namespace(bufnr, mode)
   end)
 end
 
-local function get_project_contexts(bufnr)
-  local params = {
-    _vs_textDocument = {
-      uri = vim.uri_from_bufnr(bufnr),
-    },
-  }
-
-  local clients = vim.lsp.get_clients({ bufnr = bufnr })
-  if #clients == 0 then return end
-
-  local client = clients[1] -- or pick a specific one
-
-  client:request("textDocument/_vs_getProjectContexts", params, function(err, result, ctx, _)
-    if err then
-      if err.code == vim.lsp.protocol.ErrorCodes.RequestCancelled then return end
-      vim.notify("LSP error: " .. err.message, vim.log.levels.ERROR)
-      return
-    end
-
-    -- result is VSProjectContextList
-    vim.print(result)
-  end, bufnr)
-end
-
 ---@param mode easy-dotnet.BootstrapNamespaceMode
 M.auto_bootstrap_namespace = function(mode)
   vim.api.nvim_create_autocmd({ "BufReadPost", "BufNewFile" }, {
     pattern = "*.cs",
     callback = function()
       local bufnr = vim.api.nvim_get_current_buf()
-      vim.keymap.set("n", "<leader>y", function() get_project_contexts(bufnr) end, { buffer = bufnr })
       auto_bootstrap_namespace(bufnr, mode)
     end,
   })


### PR DESCRIPTION
When new files are created while roslyn LSP is running it loads them in the "miscellaneous context" not attached to the current project. Looking through the vscode-csharp plugin I noticed they query filestate using `textDocument/_vs_getProjectContexts`. Previously I used `on_attach` to send file created events for empty files but this isnt perfect as demonstrated in #713 where the file is not empty when the LSP attaches. 


In this new approach I store a timestamp when the solution/project has loaded and when a new file is encountered I query it's state and try to send file created events for new files that do not belong to a context. This seems to work for the code action example