### PR TITLE
feat: mtp test runner - any cursor position when running test from buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Although not *required* by the plugin, it is highly recommended to install one o
           },
         mappings = {
           run_test_from_buffer = { lhs = "<leader>r", desc = "run test from buffer" },
+          run_all_tests_from_buffer = { lhs = "<leader>t", desc = "run all tests from buffer" },
           peek_stack_trace_from_buffer = { lhs = "<leader>p", desc = "peek stack trace from buffer" },
           filter_failed_tests = { lhs = "<leader>fe", desc = "filter failed tests" },
           debug_test = { lhs = "<leader>d", desc = "debug test" },

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -36,6 +36,7 @@
 
 ---@class easy-dotnet.TestRunner.Mappings
 ---@field run_test_from_buffer easy-dotnet.Keymap
+---@field run_all_tests_from_buffer easy-dotnet.Keymap
 ---@field peek_stack_trace_from_buffer easy-dotnet.Keymap
 ---@field debug_test_from_buffer easy-dotnet.Keymap
 ---@field go_to_file easy-dotnet.Keymap
@@ -123,6 +124,7 @@ local M = {
       },
       mappings = {
         run_test_from_buffer = { lhs = "<leader>r", desc = "run test from buffer" },
+        run_all_tests_from_buffer = { lhs = "<leader>t", desc = "run all tests from buffer" },
         peek_stack_trace_from_buffer = { lhs = "<leader>p", desc = "peek stack trace from buffer" },
         debug_test_from_buffer = { lhs = "<leader>d", desc = "run test from buffer" },
         filter_failed_tests = { lhs = "<leader>fe", desc = "filter failed tests" },


### PR DESCRIPTION
Currently it was possible to run MTP test from buffer only on `line_start` value, initial idea to improve it was to use `line_end` field which MTP adapters can return for discovery response.

After some investigation it turned out that `TUnit` is returning the same value as for `line_start` and `xunit` is not returning it at all, therefore for now the best solution IMO is to use treesitter to determine test method range.

Additionally added option to run all tests in buffer