### PR TITLE
feat: roslyn codelens

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -257,7 +257,7 @@ function M.enable(opts)
       ["roslyn.client.nestedCodeAction"] = require("easy-dotnet.roslyn.lsp.nested_code_action"),
       ["roslyn.client.completionComplexEdit"] = require("easy-dotnet.roslyn.lsp.complex_edit"),
       -- ["roslyn.client.peekReferences"] = require("easy-dotnet.roslyn.lsp.peek_references"),
-      -- ["dotnet.test.run"] = require("easy-dotnet.roslyn.lsp.test_run"),
+      ["dotnet.test.run"] = require("easy-dotnet.roslyn.lsp.test_run"),
     },
     handlers = {
       ["client/registerCapability"] = function(err, params, ctx, config)

--- a/lua/easy-dotnet/roslyn/lsp/test_run.lua
+++ b/lua/easy-dotnet/roslyn/lsp/test_run.lua
@@ -18,6 +18,7 @@
 ---@param command easy-dotnet.TestRunner.Command
 ---@param ctx easy-dotnet.Roslyn.CommandContext
 return function(command, ctx)
+  vim.print("Roslyn requested to run tests", command)
   local arg = command.arguments[1] -- usually only one
   local _ = ctx.client_id
   local file_uri = arg.textDocument.uri


### PR DESCRIPTION

1. check out this branch
2. open a test file
3. `:lua vim.lsp.codelens.refresh()`
4. navigate to line where it says Debug tests 
5. `:lua vim.lsp.codelens.run()`
6. a dump of command should be visible


If we are able to pass this command along to the easy-dotnet-server we can make the codelens work