### PR TITLE
bugfix: `debug_test_from_buffer` use `coroutine.wrap` on `get_projects_and_frameworks`

### DIFF
--- a/lua/easy-dotnet/test-signs.lua
+++ b/lua/easy-dotnet/test-signs.lua
@@ -68,8 +68,9 @@ local function debug_test_from_buffer()
       local project_path = node.cs_project_path
       local sln_file = sln_parse.try_get_selected_solution_file()
       assert(sln_file, "Failed to find a solution file")
-      local test_projects = sln_parse.get_projects_and_frameworks_flattened_from_sln(sln_file, function(i) return i.isTestProject end)
-      local test_project = project_path and project_path or picker.pick_sync(nil, test_projects, "Pick test project").path
+      local get_projects = coroutine.wrap(sln_parse.get_projects_and_frameworks_flattened_from_sln)
+      local test_projects = get_projects(sln_file, function(i) return i.isTestProject end)
+      local test_project = project_path or picker.pick_sync(nil, test_projects, "Pick test project").path
       assert(test_project, "No project selected")
       client:initialize(function()
         client.debugger:debugger_start({ targetPath = test_project }, function(res)


### PR DESCRIPTION
I'm getting the below error when attemtping to debug tests from buffer. This PR resolves the error by wrapping the `get_projects_and_frameworks_flattened_from_sln` function into a coroutine.



```
Error  21:56:03 msg_show.emsg E5108: Error executing lua: ...y/easy-dotnet.nvim/lua/easy-dotnet/parsers/sln-parse.lua:206: get_projects_from_sln must be called from inside a coroutine
 stack traceback:
     [C]: in function 'assert'
     ...y/easy-dotnet.nvim/lua/easy-dotnet/parsers/sln-parse.lua:206: in function 'get_projects_from_sln'
     ...y/easy-dotnet.nvim/lua/easy-dotnet/parsers/sln-parse.lua:126: in function 'get_projects_and_frameworks_flattened_from_sln'
     ...vim/lazy/easy-dotnet.nvim/lua/easy-dotnet/test-signs.lua:71: in function 'cb'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:47: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     .../easy-dotnet.nvim/lua/easy-dotnet/test-runner/render.lua:51: in function 'traverse'
     ...vim/lazy/easy-dotnet.nvim/lua/easy-dotnet/test-signs.lua:63: in function 'debug_test_from_buffer'
``` 