### PR TITLE
feat(nvim): add json5 filetype detection for .NET settings

### DIFF
--- a/lua/easy-dotnet/filetypes.lua
+++ b/lua/easy-dotnet/filetypes.lua
@@ -2,6 +2,14 @@ local M = {}
 
 M.enable_filetypes = function()
   vim.filetype.add({
+    filename = {
+      ["secrets.json"] = "json5",
+      ["launchSettings.json"] = "json5",
+      ["appsettings.json"] = "json5",
+    },
+    pattern = {
+      ["appsettings%.%a+%.json"] = "json5",
+    },
     extension = {
       props = "xml",
     },


### PR DESCRIPTION
This should improve highlighting for comments in json files and also automatically fix commentstring if you use `mini.comments` or similiar

- `secrets.json`
- `launchSettings.json`
- `appsettings.*.json`