### PR TITLE
feat: remove diagnostic dynamicRegistration from capabilities

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -341,9 +341,6 @@ function M.enable(opts)
       codeLens = {
         dynamicRegistration = true,
       },
-      diagnostic = {
-        dynamicRegistration = true,
-      },
     },
     workspace = {
       didChangeWatchedFiles = {
@@ -351,6 +348,8 @@ function M.enable(opts)
       },
     },
   })
+
+  if vim.version().minor >= 12 then vim.tbl_deep_extend("keep", cap, { textDocument = { diagnostic = { dynamicRegistration = true } } }) end
 
   ---@type vim.lsp.Config
   vim.lsp.config[constants.lsp_client_name] = {


### PR DESCRIPTION
neovim added support for diagnostic dynamicRegistration  see here
https://github.com/neovim/neovim/commit/0f3e3c87b738f1c81fa22b6e5f2a9a847d59ebd3.

Not sure if this is extra, since there isn't really much wrong with hard coding.