### PR TITLE
feat: autofix indent expression (overwrite treesitter c# indentexpr)

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -314,6 +314,10 @@ local function source_generated_autocmd()
   })
 end
 
+local function fix_indent_expression(buf)
+  if vim.api.nvim_buf_is_valid(buf) then vim.bo[buf].indentexpr = "GetCSIndent(v:lnum)" end
+end
+
 ---@param opts easy-dotnet.LspOpts
 function M.enable(opts)
   if vim.fn.has("nvim-0.11") == 0 then
@@ -400,6 +404,7 @@ function M.enable(opts)
     end,
     on_attach = function(client, buf)
       vim.b[buf].roslyn_buf_opened_at = now()
+      fix_indent_expression(buf)
       if require("easy-dotnet.options").get_option("lsp").auto_refresh_codelens then
         if vim.fn.has("nvim-0.12") == 1 then
           vim.lsp.codelens.enable(true, { bufnr = buf })


### PR DESCRIPTION
The treesitter c# indent expression is borked and doesnt work properly. Instead of adding a big flashy fix in the markdown PR for users to apply we try to simply override it in our lsp attach. 

This means that if you are using the LSP indent expression will be fixed automatically