### PR TITLE
fix: set namespace when calling vim.diagnostic.setqflist() from diagnostics command

### DIFF
--- a/lua/easy-dotnet/diagnostics.lua
+++ b/lua/easy-dotnet/diagnostics.lua
@@ -84,7 +84,7 @@ function M.populate_diagnostics(diagnostics_response, filter_func)
   vim.notify(string.format("Populated %d diagnostics across %d files", total_count, filtered_count), vim.log.levels.INFO)
 
   local options = require("easy-dotnet.options").options
-  if options.diagnostics and options.diagnostics.setqflist then vim.diagnostic.setqflist() end
+  if options.diagnostics and options.diagnostics.setqflist then vim.diagnostic.setqflist({ namespace = ns }) end
 end
 
 return M


### PR DESCRIPTION
Other diagnostics (e.g. hints in open buffers) will be shown in the qflist for the `:Dotnet diagnostic warnings` and `:Dotnet diagnostic errors` commands unless the namepsace option is used for setqflist().