### PR TITLE
docs: add missing run_all_tests_from_buffer keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Although not *required* by the plugin, it is highly recommended to install one o
         },
         mappings = {
           run_test_from_buffer = { lhs = "<leader>r", desc = "run test from buffer" },
+          run_all_tests_from_buffer = { lhs = "<leader>t", desc = "Run all tests in file" },
           get_build_errors = { lhs = "<leader>e", desc = "get build errors" },
           peek_stack_trace_from_buffer = { lhs = "<leader>p", desc = "peek stack trace from buffer" },
           debug_test_from_buffer = { lhs = "<leader>d", desc = "run test from buffer" },

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -45,6 +45,7 @@
 
 ---@class easy-dotnet.TestRunner.Mappings
 ---@field run_test_from_buffer easy-dotnet.Keymap
+---@field run_all_tests_from_buffer easy-dotnet.Keymap
 ---@field get_build_errors easy-dotnet.Keymap
 ---@field peek_stack_trace_from_buffer easy-dotnet.Keymap
 ---@field debug_test_from_buffer easy-dotnet.Keymap
@@ -121,6 +122,7 @@ local M = {
       },
       mappings = {
         run_test_from_buffer = { lhs = "<leader>r", desc = "run test from buffer" },
+        run_all_tests_from_buffer = { lhs = "<leader>t", desc = "Run all tests in file" },
         get_build_errors = { lhs = "<leader>e", desc = "get build errors" },
         peek_stack_trace_from_buffer = { lhs = "<leader>p", desc = "peek stack trace from buffer" },
         debug_test_from_buffer = { lhs = "<leader>d", desc = "run test from buffer" },


### PR DESCRIPTION
Exposes `run_all_tests_from_buffer` default key mapping set in [buffer.lua](https://github.com/GustavEikaas/easy-dotnet.nvim/blob/06cc3c7ffd02ef6c62dffea46d4f6e53f1962ef2/lua/easy-dotnet/test-runner/buffer.lua#L246) in README and adds it to the options type.