### PR TITLE
fix(terminal): use winbar for run header to avoid occluding output

### DIFF
--- a/lua/easy-dotnet/terminal/header.lua
+++ b/lua/easy-dotnet/terminal/header.lua
@@ -2,7 +2,6 @@ local spinner_frames = require("easy-dotnet.ui-modules.jobs").spinner_frames
 
 local function get_state() return require("easy-dotnet.terminal").state end
 
-local ns_id = vim.api.nvim_create_namespace("EasyDotnetHeader")
 local spinner_idx = 1
 
 local function cleanup_header()
@@ -12,7 +11,7 @@ local function cleanup_header()
     if not state.timer:is_closing() then state.timer:close() end
     state.timer = nil
   end
-  if state.header_win and vim.api.nvim_win_is_valid(state.header_win) then vim.api.nvim_win_close(state.header_win, true) end
+  if state.win and vim.api.nvim_win_is_valid(state.win) then pcall(vim.api.nvim_set_option_value, "winbar", "", { win = state.win }) end
   state.header_win = nil
   state.header_buf = nil
 end
@@ -25,18 +24,8 @@ local function update_header(status, exit_code)
     cleanup_header()
     return
   end
-  if not state.header_buf or not vim.api.nvim_win_is_valid(state.header_win) then return end
 
   local curr_width = vim.api.nvim_win_get_width(state.win)
-  if vim.api.nvim_win_get_width(state.header_win) ~= curr_width then
-    vim.api.nvim_win_set_config(state.header_win, {
-      width = curr_width,
-      relative = "win",
-      win = state.win,
-      row = 0,
-      col = 0,
-    })
-  end
 
   local icon, icon_hl
   if status == "running" then
@@ -62,43 +51,15 @@ local function update_header(status, exit_code)
   local display_args = full_args
   if #display_args > max_len then display_args = display_args:sub(1, max_len) .. "..." end
 
-  local padding_left = 1
-  local content_string = string.format("%s %s %s", icon, exec_name, display_args)
-  local final_line = string.rep(" ", padding_left) .. content_string
+  local winbar = string.format(" %%#%s#%s%%* %%#Title#%s%%* %%#Comment#%s%%*", icon_hl, icon, exec_name, display_args)
 
-  vim.api.nvim_buf_set_lines(state.header_buf, 0, -1, false, { final_line })
-  vim.api.nvim_buf_clear_namespace(state.header_buf, ns_id, 0, -1)
-
-  local start_icon = padding_left
-  local end_icon = start_icon + #icon
-  local start_exec = end_icon + 1
-  local end_exec = start_exec + #exec_name
-  local start_args = end_exec + 1
-  local end_args = start_args + #display_args
-
-  vim.hl.range(state.header_buf, ns_id, icon_hl, { 0, start_icon }, { 0, end_icon })
-  vim.hl.range(state.header_buf, ns_id, "Title", { 0, start_exec }, { 0, end_exec })
-  vim.hl.range(state.header_buf, ns_id, "Comment", { 0, start_args }, { 0, end_args })
+  pcall(vim.api.nvim_set_option_value, "winbar", winbar, { win = state.win })
 end
 
 local function create_header_win()
   local state = get_state()
   if not state.win or not vim.api.nvim_win_is_valid(state.win) then return end
-  if state.header_win and vim.api.nvim_win_is_valid(state.header_win) then vim.api.nvim_win_close(state.header_win, true) end
-
-  state.header_buf = vim.api.nvim_create_buf(false, true)
-  state.header_win = vim.api.nvim_open_win(state.header_buf, false, {
-    relative = "win",
-    win = state.win,
-    row = 0,
-    col = 0,
-    width = vim.api.nvim_win_get_width(state.win),
-    height = 1,
-    style = "minimal",
-    focusable = false,
-    zindex = 100,
-  })
-  vim.api.nvim_set_option_value("winhighlight", "Normal:NormalFloat,FloatBorder:FloatBorder", { win = state.header_win })
+  pcall(vim.api.nvim_set_option_value, "winbar", " ", { win = state.win })
 end
 
 return {


### PR DESCRIPTION
## Problem

The run-output terminal header is rendered as a 1-row floating window pinned at `row = 0, col = 0` with `zindex = 100` over the terminal split. Because the float sits on top of the terminal's first visible row, the program's first line of stdout is hidden behind the header.

### Reproduction

```
Console.WriteLine("LINE-1");
Console.WriteLine("LINE-2");
Console.WriteLine("LINE-3");
Thread.Sleep(2000);
```

Run via `:Dotnet run`. Expected: three lines visible. Actual: only LINE-2 and LINE-3 are visible - LINE-1 is rendered into the buffer but immediately covered by the float.

This affects every short-output run.

## Fix

Switch the header from a floating window to the window's native `winbar`. `winbar` reserves a real row owned by the window itself, so the terminal contents render below it with no overlap possible.

- Highlights are expressed via winbar's `%#GROUP#` syntax instead of an extmark namespace, so the spinner / status icon / executable name / args still get the same coloring (`DiagnosticInfo`, `String`, `ErrorMsg`, `Title`, `Comment`).
- `cleanup_header` now sets `winbar = ""` on the terminal window (guarded with `pcall` for safety when the window is being closed).
- `create_header_win` sets a placeholder `winbar = " "` so the row is reserved before the first `update_header` arrives.
- The unused `header_buf` / `header_win` / `ns_id` bookkeeping is removed.

The public API of the module (`cleanup_header`, `create_header_win`, `update_header(status, exit_code)`) is unchanged, so call sites in `run_command_managed.lua` and `terminal/init.lua` work without modification.

## Testing

- Verified manually with the reproduction above - all three lines are now visible after the fix.
- Verified the spinner / running / finished-success (✓) / finished-failure () states all render correctly in the winbar.
- Headless smoke tests cover: winbar set on create, content updated on running/finished, error icon on non-zero exit, winbar cleared on cleanup, no-op behavior when the window is gone.
- `stylua --check` passes against the project's `stylua.toml`.