### PR TITLE
change dotnet ef not installed error to warn

### DIFF
--- a/lua/easy-dotnet/health.lua
+++ b/lua/easy-dotnet/health.lua
@@ -18,6 +18,21 @@ local function ensure_dep_installed(command, advice)
   end
 end
 
+---@param command  table<string>
+---@param advice  string | nil
+local function check_optional_dep_configured(command, advice)
+  local exec = command
+  advice = advice or ""
+  local success = pcall(function() vim.fn.system(exec) end)
+  local cmd_name = table.concat(vim.tbl_filter(function(item) return type(item) == "string" and not item:match("^%-") end, exec), " ")
+  if success and vim.v.shell_error == 0 then
+    vim.health.ok(cmd_name .. " is installed")
+  else
+    print("" .. vim.v.shell_error)
+    vim.health.warn(cmd_name .. " is not installed", { advice })
+  end
+end
+
 ---@param required boolean | nil
 local function ensure_nvim_dep_installed(pkg, advice, required)
   if required == nil then required = true end
@@ -187,7 +202,7 @@ M.check = function()
   vim.health.start("easy-dotnet CLI dependencies")
   ensure_dep_installed({ "dotnet", "-h" })
   ensure_dep_installed({ "dotnet-easydotnet", "-v" }, "dotnet tool install --global EasyDotnet  | Add path to shell https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install")
-  ensure_dep_installed({ "dotnet", "ef" }, "dotnet tool install --global dotnet-ef")
+  check_optional_dep_configured({ "dotnet", "ef" }, "dotnet tool install --global dotnet-ef")
 
   vim.health.start("easy-dotnet lua dependencies")
   ensure_nvim_dep_installed("plenary", "https://github.com/nvim-lua/plenary.nvim")


### PR DESCRIPTION
Changes the checkhealth error message to a warning for `dotnet ef` since its optional.

Closes #935 