### PR TITLE
feat: enable projx lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ Although not *required* by the plugin, it is highly recommended to install one o
      },
       -- Optional configuration for external terminals (matches nvim-dap structure)
       external_terminal = nil,
+      projx_lsp = {
+        enabled = true,
+      },
       lsp = {
         enabled = true, -- Enable builtin roslyn lsp
         set_fold_expr = false,

--- a/lua/easy-dotnet/health.lua
+++ b/lua/easy-dotnet/health.lua
@@ -95,7 +95,7 @@ local function check_cmp()
     if type(cmp.get_registered_sources) == "function" then
       for _, value in ipairs(cmp.get_registered_sources()) do
         if value.name == "easy-dotnet" then
-          vim.health.ok("cmp source configured correctly")
+          vim.health.warn("cmp source configured, use projx_lsp instead")
           return
         end
       end
@@ -105,12 +105,10 @@ local function check_cmp()
   if pcall(require, "blink.cmp.config") then
     local blink_config = require("blink.cmp.config")
     if blink_config.sources.providers["easy-dotnet"] then
-      vim.health.ok("cmp source configured correctly")
+      vim.health.warn("cmp source configured, use projx_lsp instead")
       return
     end
   end
-
-  vim.health.warn("cmp source not configured", { "https://github.com/GustavEikaas/easy-dotnet.nvim?tab=readme-ov-file#package-autocomplete" })
 end
 
 local function os_info()

--- a/lua/easy-dotnet/options.lua
+++ b/lua/easy-dotnet/options.lua
@@ -193,7 +193,7 @@ local M = {
       auto_register_dap = true,
     },
     projx_lsp = {
-      enabled = false,
+      enabled = true,
     },
     lsp = {
       enabled = true,


### PR DESCRIPTION
Better to use an LSP for `.csproj` files rather than using the blink.cmp/nvim-cmp completion source