### PR TITLE
feat: add roslyn prefix to init msg

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -448,10 +448,11 @@ function M.enable(opts)
 
       local uri = vim.uri_from_fname(file)
       if type == "sln" then
-        M.state[client.id] = job.register_job({ name = "Opening solution", on_error_text = "Failed to open solution", on_success_text = "Workspace ready", timeout = 150000 })
+        M.state[client.id] =
+          job.register_job({ name = "[roslyn] Loading solution", on_error_text = "[roslyn] Failed to open solution", on_success_text = "[roslyn] Workspace ready", timeout = 150000 })
         client:notify("solution/open", { solution = uri })
       elseif type == "csproj" then
-        M.state[client.id] = job.register_job({ name = "Opening project", on_error_text = "Failed to open project", on_success_text = "Workspace ready", timeout = 15000 })
+        M.state[client.id] = job.register_job({ name = "[roslyn] Loading project", on_error_text = "[roslyn] Failed to open project", on_success_text = "[roslyn] Workspace ready", timeout = 15000 })
         client:notify("project/open", { projects = { uri } })
       else
         logger.warn("Unknown file selected as root_file " .. file)


### PR DESCRIPTION
Both server and roslyn writes a message saying its loading the solution, this PR prefixes LSP message with `[roslyn]` to try and clarify this