### PR TITLE
feat(roslyn): hide in-process-lsp behind FT

### DIFF
--- a/lua/easy-dotnet/in-process-lsp/import-missing-namespaces.lua
+++ b/lua/easy-dotnet/in-process-lsp/import-missing-namespaces.lua
@@ -138,7 +138,7 @@ local function request_actions_for_diag(bufnr, client, diag, cb)
     end
 
     local has_multiple_potential_namespaces = #result > 1
-    if has_multiple_potential_namespaces > 1 then
+    if has_multiple_potential_namespaces then
       cb({})
       return
     end

--- a/lua/easy-dotnet/init.lua
+++ b/lua/easy-dotnet/init.lua
@@ -284,9 +284,9 @@ M.setup = function(opts)
     local lsp = require("easy-dotnet.roslyn.lsp")
     lsp.enable(merged_opts.lsp)
     lsp.preload_roslyn(merged_opts.lsp)
+    require("easy-dotnet.in-process-lsp.lsp").enable()
   end
   if merged_opts.projx_lsp.enabled == true then require("easy-dotnet.projx.lsp").enable() end
-  require("easy-dotnet.in-process-lsp.lsp").enable()
   wrap(auto_register_dap)(merged_opts)
   wrap(auto_start_testrunner)()
   wrap(auto_install_easy_dotnet)()


### PR DESCRIPTION
IMO doesn't make sense to enable in-process lsp when roslyn LSP integration is disabled