### PR TITLE
chore(lsp): remove lsp initialization progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,21 @@ Just open a C#, Razor, or CSHTML file and the official .NET language server star
 If `roslyn-language-server` is missing, easy-dotnet will install the global tool with `dotnet tool install --global roslyn-language-server --prerelease`.
 Existing installs are not updated automatically; run `dotnet-easydotnet roslyn update` when an update is suggested.
 
+This dotnet tool exists at two places:
+  * [nuget.org], which is not updated that often.
+  * [Azure Devops feed], where updates happen multiple times a day.
+
+ ```bash
+  # Installing the tool using the more recent Azure Devops feed
+  dotnet tool install -g roslyn-language-server --prerelease --source https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+  # Installing the tool from nuget.org
+  dotnet tool install -g roslyn-language-server --prerelease
+
+  # Updating works the same way as installing ( by replacing "install" with "update")
+  dotnet tool update -g roslyn-language-server --prerelease --source https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+  ```
+
 Razor support also uses VS Code's HTML language server for markup completions, hover, formatting, and related requests.
 easy-dotnet does **not** bundle or auto-install this Node dependency.
 Install it globally with `npm install -g vscode-langservers-extracted`, or per project with `npm install --save-dev vscode-langservers-extracted`.
@@ -1030,3 +1045,7 @@ Check out [setup guide](./docs/server-development.md)
 <a href="https://github.com/GustavEikaas/easy-dotnet.nvim/graphs/contributors">
 <img src="https://contrib.rocks/image?repo=GustavEikaas/easy-dotnet.nvim" />
 </a>
+
+
+[nuget.org]: https://www.nuget.org/packages/roslyn-language-server
+[Azure Devops feed]: https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuGet/roslyn-language-server.linux-x64

--- a/README.md
+++ b/README.md
@@ -551,6 +551,10 @@ This dotnet tool exists at two places:
   * [nuget.org], which is not updated that often.
   * [Azure Devops feed], where updates happen multiple times a day.
 
+> [!IMPORTANT]  
+> The version used in vscode can be extracted [here](https://github.com/dotnet/vscode-csharp/blob/main/package.json#L43).  
+> The extension uses the [Azure Devops feed] as well.
+
  ```bash
   # Installing the tool using the more recent Azure Devops feed
   dotnet tool install -g roslyn-language-server --prerelease --source https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json

--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -1,4 +1,3 @@
-local job = require("easy-dotnet.ui-modules.jobs")
 local logger = require("easy-dotnet.logger")
 local root_finder = require("easy-dotnet.roslyn.root_finder")
 local sln_parse = require("easy-dotnet.parsers.sln-parse")

--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -573,11 +573,8 @@ function M.enable(opts)
 
       local uri = vim.uri_from_fname(file)
       if type == "sln" then
-        M.state[client.id] =
-          job.register_job({ name = "[roslyn] Loading solution", on_error_text = "[roslyn] Failed to open solution", on_success_text = "[roslyn] Workspace ready", timeout = 150000 })
         client:notify("solution/open", { solution = uri })
       elseif type == "csproj" then
-        M.state[client.id] = job.register_job({ name = "[roslyn] Loading project", on_error_text = "[roslyn] Failed to open project", on_success_text = "[roslyn] Workspace ready", timeout = 15000 })
         client:notify("project/open", { projects = { uri } })
       else
         logger.warn("Unknown file selected as root_file " .. file)


### PR DESCRIPTION
Reporting intialization progress is implemented in roslyn directly now. 
Add instructions on how to get the latest lsp tool from Azure dev ops feed

https://github.com/dotnet/roslyn/pull/84399