### PR TITLE
chore(roslyn): don't use private method for diagnostic refresh

### DIFF
--- a/lua/easy-dotnet/commands.lua
+++ b/lua/easy-dotnet/commands.lua
@@ -568,18 +568,4 @@ M.terminal = {
   },
 }
 
-M.lsp = {
-  subcommands = {
-    start = {
-      handle = function() require("easy-dotnet.roslyn.lsp").start() end,
-    },
-    restart = {
-      handle = function() require("easy-dotnet.roslyn.lsp").restart() end,
-    },
-    stop = {
-      handle = function() require("easy-dotnet.roslyn.lsp").stop() end,
-    },
-  },
-}
-
 return M

--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -15,51 +15,6 @@ local M = {
 }
 local function now() return vim.uv.now() end
 
-local function is_roslyn_filetype(ft) return ft == "cs" or ft == "razor" end
-
-local function is_buffer_in_root(bufnr, root_dir)
-  if not root_dir then return true end
-
-  local name = vim.api.nvim_buf_get_name(bufnr)
-  if name == "" or name:match("^%a+://") then return false end
-
-  local root = vim.fs.normalize(vim.fn.fnamemodify(root_dir, ":p"))
-  local path = vim.fs.normalize(vim.fn.fnamemodify(name, ":p"))
-  if path == root then return true end
-
-  if not root:match("[/\\]$") then root = root .. "/" end
-  return path:sub(1, #root) == root
-end
-
----@param root_dir string|nil
-function M.start(root_dir)
-  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if vim.api.nvim_buf_is_loaded(bufnr) then
-      local ft = vim.bo[bufnr].filetype
-      if is_roslyn_filetype(ft) and vim.bo[bufnr].buftype == "" and is_buffer_in_root(bufnr, root_dir) then
-        vim.api.nvim_buf_call(bufnr, function()
-          vim.api.nvim_exec_autocmds("FileType", {
-            buffer = bufnr,
-          })
-        end)
-      end
-    end
-  end
-end
-
-function M.stop()
-  local bufnr = vim.api.nvim_get_current_buf()
-  local attached_clients = vim.lsp.get_clients({ bufnr = bufnr, name = constants.lsp_client_name })
-  for _, client in ipairs(attached_clients) do
-    client:stop(true)
-  end
-end
-
-function M.restart()
-  M.stop()
-  M.start()
-end
-
 local function restart_root(root_dir)
   logger.info("[easy-dotnet] Git branch changed; restarting Roslyn")
   pcall(vim.cmd, "checktime")
@@ -223,7 +178,7 @@ end
 local function refresh_diag(client)
   ---https://github.com/neovim/nvim-lspconfig/pull/4474
   ---Avoid using vim.lsp.diagnostic._refresh since it is removed from nightly
-  local capabilities = vim.iter(client.dynamic_capabilities.capabilities.diagnosticProvider):map(function(cap) return cap.registerOptions.identifier end):totable()
+  local capabilities = vim.iter(client.dynamic_capabilities.capabilities.diagnosticProvider or {}):map(function(cap) return cap.registerOptions.identifier end):totable()
 
   for buf, _ in pairs(client.attached_buffers) do
     if vim.api.nvim_buf_is_loaded(buf) then

--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -221,21 +221,20 @@ end
 
 ---@param client vim.lsp.Client
 local function refresh_diag(client)
-  local bufnr = vim.api.nvim_get_current_buf()
-  if not vim.api.nvim_buf_is_valid(bufnr) then return end
+  ---https://github.com/neovim/nvim-lspconfig/pull/4474
+  ---Avoid using vim.lsp.diagnostic._refresh since it is removed from nightly
+  local capabilities = vim.iter(client.dynamic_capabilities.capabilities.diagnosticProvider):map(function(cap) return cap.registerOptions.identifier end):totable()
 
-  local open_doc = client.server_capabilities and client.attached_buffers and client.attached_buffers[bufnr]
-  if not open_doc then return end
-
-  local params = {
-    textDocument = {
-      uri = vim.uri_from_bufnr(bufnr),
-      version = vim.lsp.util.buf_versions[bufnr] or 0,
-    },
-    contentChanges = {},
-  }
-
-  client:notify("textDocument/didChange", params)
+  for buf, _ in pairs(client.attached_buffers) do
+    if vim.api.nvim_buf_is_loaded(buf) then
+      for _, cap in pairs(capabilities) do
+        client:request(vim.lsp.protocol.Methods.textDocument_diagnostic, {
+          identifier = cap,
+          textDocument = vim.lsp.util.make_text_document_params(buf),
+        }, nil, buf)
+      end
+    end
+  end
 end
 
 local default_roslyn_settings = {
@@ -328,6 +327,7 @@ local function populate_source_generated_buffer(client, buf, file)
     if text == vim.NIL or type(text) ~= "string" then text = "" end
     text = text:gsub("\r\n", "\n")
     vim.bo[buf].modifiable = true
+    vim.bo[buf].readonly = false
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(text, "\n", { plain = true, trimempty = true }))
     vim.lsp.buf_attach_client(buf, client.id)
     set_virtual_buffer_props(buf)
@@ -630,7 +630,9 @@ function M.enable(opts)
           M.solution_loaded[client.id] = true
         end, 2000)
 
-        vim.defer_fn(function() refresh_diag(client) end, 500)
+        -- This will no longer be needed in 0.13
+        -- in nightly after https://github.com/neovim/neovim/pull/40623
+        refresh_diag(client)
       end,
       ["workspace/textDocumentContent/refresh"] = function(_, _, ctx)
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
@@ -642,9 +644,7 @@ function M.enable(opts)
           end
         end
 
-        for bufnr in pairs(client.attached_buffers) do
-          vim.lsp.diagnostic._refresh(bufnr, ctx.client_id)
-        end
+        refresh_diag(client)
 
         return vim.NIL
       end,


### PR DESCRIPTION
`vim.diagnostic._refresh` was removed in nightly. I've taken solution from `nvim-lspconfig` repo to handle this
Related: https://github.com/neovim/nvim-lspconfig/pull/4474

I also removed `lsp start/stop/restart` commands since they are available in neovim 0.12