### PR TITLE
fix(roslyn): pass-by-reference mutation in pending file watchers

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -560,7 +560,7 @@ function M.enable(opts)
               if not M.solution_loaded[client_id] then
                 -- Cache the entire registration (will register in bulk on solution/open)
                 if not M.pending_watchers[client_id] then M.pending_watchers[client_id] = {} end
-                table.insert(M.pending_watchers[client_id], registration)
+                table.insert(M.pending_watchers[client_id], vim.deepcopy(registration))
                 -- Block the registration
                 registration.registerOptions.watchers = {}
               end


### PR DESCRIPTION
`registration` is inserted into `M.pending_watchers` by reference. The subsequent `registration.registerOptions.watchers = {}` assignment clears the cached array as well, resulting in an empty watchers list when the solution finally loads.

Fixed by wrapping the cached object in `vim.deepcopy()`.