### PR TITLE
fix(roslyn): restart on branch change

### DIFF
--- a/lua/easy-dotnet/roslyn/lsp.lua
+++ b/lua/easy-dotnet/roslyn/lsp.lua
@@ -15,6 +15,37 @@ local M = {
 }
 local function now() return vim.uv.now() end
 
+local function is_roslyn_filetype(ft) return ft == "cs" or ft == "razor" end
+
+local function is_buffer_in_root(bufnr, root_dir)
+  if not root_dir then return true end
+
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  if name == "" or name:match("^%a+://") then return false end
+
+  local root = vim.fs.normalize(vim.fn.fnamemodify(root_dir, ":p"))
+  local path = vim.fs.normalize(vim.fn.fnamemodify(name, ":p"))
+  if path == root then return true end
+
+  if not root:match("[/\\]$") then root = root .. "/" end
+  return path:sub(1, #root) == root
+end
+
+---@param root_dir string|nil
+local function start(root_dir)
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      local ft = vim.bo[bufnr].filetype
+      if is_roslyn_filetype(ft) and vim.bo[bufnr].buftype == "" and is_buffer_in_root(bufnr, root_dir) then
+        vim.api.nvim_buf_call(bufnr, function()
+          vim.api.nvim_exec_autocmds("FileType", {
+            buffer = bufnr,
+          })
+        end)
+      end
+    end
+  end
+end
 local function restart_root(root_dir)
   logger.info("[easy-dotnet] Git branch changed; restarting Roslyn")
   pcall(vim.cmd, "checktime")
@@ -23,7 +54,7 @@ local function restart_root(root_dir)
     if client.root_dir == root_dir then client:stop(true) end
   end
 
-  vim.defer_fn(function() M.start(root_dir) end, 250)
+  vim.defer_fn(function() start(root_dir) end, 250)
 end
 
 ---@param client vim.lsp.Client


### PR DESCRIPTION
Bring back lsp `start` function that is used for restarting roslyn after git branch change