### PR TITLE
fix(workspace_edit): prevent creating unloaded buffers

### DIFF
--- a/lua/easy-dotnet/actions/new.lua
+++ b/lua/easy-dotnet/actions/new.lua
@@ -333,6 +333,7 @@ local function name_input_sync(default) return vim.fn.input({ prompt = "Enter na
 
 ---@param path string
 ---@param cb function | nil
+---@deprecated
 M.create_new_item = function(path, cb)
   path = path or "."
   local template = require("easy-dotnet.picker").pick_sync(nil, {

--- a/lua/easy-dotnet/rpc/handlers/apply_workspace_edit.lua
+++ b/lua/easy-dotnet/rpc/handlers/apply_workspace_edit.lua
@@ -1,3 +1,4 @@
+---@param params lsp.WorkspaceEdit
 return function(params, response, throw, _)
   if type(params) ~= "table" or type(params.documentChanges) ~= "table" then
     throw({ code = -32602, message = "Missing required parameter: 'documentChanges'" })
@@ -8,14 +9,16 @@ return function(params, response, throw, _)
 
   for _, change in ipairs(params.documentChanges) do
     if change.textDocument and change.textDocument.uri then
-      local bufnr = vim.uri_to_bufnr(change.textDocument.uri)
-      local current_ver
-      if type(client_versions) == "function" then
-        current_ver = client_versions()[bufnr]
-      else
-        current_ver = client_versions[bufnr]
+      local bufnr = vim.fn.bufnr(vim.uri_to_fname(change.textDocument.uri))
+      if bufnr ~= -1 then
+        local current_ver
+        if type(client_versions) == "function" then
+          current_ver = client_versions()[bufnr]
+        else
+          current_ver = client_versions[bufnr]
+        end
+        change.textDocument.version = current_ver or 0
       end
-      change.textDocument.version = current_ver or 0
     end
   end
 
@@ -28,7 +31,7 @@ return function(params, response, throw, _)
   for _, change in ipairs(params.documentChanges) do
     local uri = change.textDocument and change.textDocument.uri
     if type(uri) == "string" then
-      local bufnr = vim.uri_to_bufnr(uri)
+      local bufnr = vim.fn.bufnr(vim.uri_to_fname(uri))
       if vim.api.nvim_buf_is_valid(bufnr) then vim.schedule(function()
         pcall(vim.api.nvim_buf_call, bufnr, function() vim.cmd("silent! update") end)
       end) end

--- a/lua/easy-dotnet/rpc/handlers/apply_workspace_edit.lua
+++ b/lua/easy-dotnet/rpc/handlers/apply_workspace_edit.lua
@@ -7,9 +7,12 @@ return function(params, response, throw, _)
 
   local client_versions = vim.lsp.util.buf_versions or {}
 
+  -- backwards compatibility with easy-dotnet < 3.4.18
+  local contains_create_file_edit = vim.iter(params.documentChanges):any(function(change) return change.kind == "create" end)
+
   for _, change in ipairs(params.documentChanges) do
     if change.textDocument and change.textDocument.uri then
-      local bufnr = vim.fn.bufnr(vim.uri_to_fname(change.textDocument.uri))
+      local bufnr = not contains_create_file_edit and vim.uri_to_bufnr(change.textDocument.uri) or vim.fn.bufnr(vim.uri_to_fname(change.textDocument.uri))
       if bufnr ~= -1 then
         local current_ver
         if type(client_versions) == "function" then
@@ -32,9 +35,7 @@ return function(params, response, throw, _)
     local uri = change.textDocument and change.textDocument.uri
     if type(uri) == "string" then
       local bufnr = vim.fn.bufnr(vim.uri_to_fname(uri))
-      if vim.api.nvim_buf_is_valid(bufnr) then vim.schedule(function()
-        pcall(vim.api.nvim_buf_call, bufnr, function() vim.cmd("silent! update") end)
-      end) end
+      if vim.api.nvim_buf_is_valid(bufnr) then pcall(vim.api.nvim_buf_call, bufnr, function() vim.cmd("silent! update") end) end
     end
   end
 

--- a/news.md
+++ b/news.md
@@ -210,6 +210,7 @@ dotnet.setup({
     -- local linux_term = { command = "kitty", args = { "--hold", "--" } }
     external_terminal = nil,
 })
+```
 
 ## Test Runner v2 ([#838](https://github.com/GustavEikaas/easy-dotnet.nvim/pull/838))
 


### PR DESCRIPTION
Looks like `vim.uri_to_bufnr` function creates unloaded buffer if it does not exist yet so I changed it to not collide with `CreateFile` workspace edit implemented here https://github.com/GustavEikaas/easy-dotnet-server/pull/485/changes