### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,9 +1043,9 @@ Check out [setup guide](./docs/server-development.md)
 ## Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&theme=dark&legend=top-left" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&legend=top-left" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&legend=top-left" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&theme=dark&legend=top-left" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&legend=top-left" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GustavEikaas/easy-dotnet.nvim&type=date&legend=top-left" />
 </picture>
 
 ## Contributors


### PR DESCRIPTION
The star history chart on the README is no longer rendering because of GitHub stargazer API restrictions. This switches the chart to a working endpoint so the stargazer history is visible again.